### PR TITLE
IFDM-88: Update Savings Calculator math

### DIFF
--- a/app/interactives/savings-calculator/page.tsx
+++ b/app/interactives/savings-calculator/page.tsx
@@ -108,15 +108,15 @@ export default function SavingsCalculator() {
       const remainingAmount = savingsGoal - futureValueOfInitial;
 
       if (remainingAmount <= 0) {
-        const monthlyNeeded = 0;
+        const contributionNeeded = 0;
         setResults({
-          contributionPerPeriod: monthlyNeeded,
+          contributionPerPeriod: contributionNeeded,
           totalDeposited: currentBalance,
           interestEarned: savingsGoal - currentBalance,
           finalBalance: savingsGoal,
           timeInMonths: totalTimeInMonths,
         });
-        setYearlyBreakdown(calculateYearlyBreakdown(monthlyNeeded, totalPeriods));
+        setYearlyBreakdown(calculateYearlyBreakdown(contributionNeeded, totalPeriods));
       } else {
         const requiredContributionPerPeriod =
           remainingAmount / ((Math.pow(1 + ratePerPeriod, totalPeriods) - 1) / ratePerPeriod);
@@ -132,7 +132,7 @@ export default function SavingsCalculator() {
         setYearlyBreakdown(calculateYearlyBreakdown(requiredContributionPerPeriod, totalPeriods));
       }
     } else if (mode === "future-balance") {
-      // Calculate future balance with current monthly contribution
+      // Calculate future balance with current contribution
       const futureValueOfInitial = currentBalance * Math.pow(1 + ratePerPeriod, totalPeriods);
       const futureValueOfAnnuity =
         contributionPerPeriod * ((Math.pow(1 + ratePerPeriod, totalPeriods) - 1) / ratePerPeriod);

--- a/app/interactives/savings-calculator/page.tsx
+++ b/app/interactives/savings-calculator/page.tsx
@@ -107,30 +107,42 @@ export default function SavingsCalculator() {
       const futureValueOfInitial = currentBalance * Math.pow(1 + ratePerPeriod, totalPeriods);
       const remainingAmount = savingsGoal - futureValueOfInitial;
 
-      if (remainingAmount <= 0) {
-        const contributionNeeded = 0;
-        setResults({
-          contributionPerPeriod: contributionNeeded,
-          totalDeposited: currentBalance,
-          interestEarned: savingsGoal - currentBalance,
-          finalBalance: savingsGoal,
-          timeInMonths: totalTimeInMonths,
-        });
-        setYearlyBreakdown(calculateYearlyBreakdown(contributionNeeded, totalPeriods));
-      } else {
-        const requiredContributionPerPeriod =
-          remainingAmount / ((Math.pow(1 + ratePerPeriod, totalPeriods) - 1) / ratePerPeriod);
-        const totalDeposited = currentBalance + requiredContributionPerPeriod * totalPeriods;
+        if (remainingAmount <= 0) {
+          const contributionNeeded = 0;
+          setResults({
+            contributionPerPeriod: contributionNeeded,
+            totalDeposited: currentBalance,
+            interestEarned: savingsGoal - currentBalance,
+            finalBalance: savingsGoal,
+            timeInMonths: totalTimeInMonths,
+          });
+          setYearlyBreakdown(calculateYearlyBreakdown(contributionNeeded, totalPeriods));
+        } else if (totalPeriods < 1) {
+          // If time to goal is less than one compounding period, ignore interest
+          const requiredContributionPerPeriod = savingsGoal - currentBalance;
+          const totalDeposited = currentBalance + requiredContributionPerPeriod;
+          setResults({
+            contributionPerPeriod: requiredContributionPerPeriod,
+            totalDeposited: totalDeposited,
+            interestEarned: 0,
+            finalBalance: savingsGoal,
+            timeInMonths: totalTimeInMonths,
+          });
+          setYearlyBreakdown(calculateYearlyBreakdown(requiredContributionPerPeriod, totalPeriods));
+        } else {
+          const requiredContributionPerPeriod =
+            remainingAmount / ((Math.pow(1 + ratePerPeriod, totalPeriods) - 1) / ratePerPeriod);
+          const totalDeposited = currentBalance + requiredContributionPerPeriod * totalPeriods;
 
-        setResults({
-          contributionPerPeriod: requiredContributionPerPeriod,
-          totalDeposited: totalDeposited,
-          interestEarned: savingsGoal - totalDeposited,
-          finalBalance: savingsGoal,
-          timeInMonths: totalTimeInMonths,
-        });
-        setYearlyBreakdown(calculateYearlyBreakdown(requiredContributionPerPeriod, totalPeriods));
-      }
+          setResults({
+            contributionPerPeriod: requiredContributionPerPeriod,
+            totalDeposited: totalDeposited,
+            interestEarned: savingsGoal - totalDeposited,
+            finalBalance: savingsGoal,
+            timeInMonths: totalTimeInMonths,
+          });
+          setYearlyBreakdown(calculateYearlyBreakdown(requiredContributionPerPeriod, totalPeriods));
+        }
     } else if (mode === "future-balance") {
       // Calculate future balance with current contribution
       const futureValueOfInitial = currentBalance * Math.pow(1 + ratePerPeriod, totalPeriods);

--- a/app/interactives/savings-calculator/page.tsx
+++ b/app/interactives/savings-calculator/page.tsx
@@ -14,7 +14,7 @@ type CalculationMode = "monthly-savings" | "time-to-goal" | "future-balance"
 type CompoundingFrequency = "monthly" | "quarterly" | "annually" | "semi-annually"
 
 interface CalculationResults {
-  monthlyContribution: number
+  contributionPerPeriod: number
   totalDeposited: number
   interestEarned: number
   finalBalance: number
@@ -47,12 +47,12 @@ export default function SavingsCalculator() {
   const [timeMonths, setTimeMonths] = useState(3)
   const [interestRate, setInterestRate] = useState(5.0)
   const [compounding, setCompounding] = useState<CompoundingFrequency>("monthly")
-  const [monthlyContribution, setMonthlyContribution] = useState(203)
+  const [contributionPerPeriod, setcontributionPerPeriod] = useState(203)
   const [showBreakdown, setShowBreakdown] = useState(false)
   const MAX_MONTHS = 11;
 
   const [results, setResults] = useState<CalculationResults>({
-    monthlyContribution: 203,
+    contributionPerPeriod: 203,
     totalDeposited: 7424,
     interestEarned: 576,
     finalBalance: 8000,
@@ -110,7 +110,7 @@ export default function SavingsCalculator() {
       if (remainingAmount <= 0) {
         const monthlyNeeded = 0;
         setResults({
-          monthlyContribution: monthlyNeeded,
+          contributionPerPeriod: monthlyNeeded,
           totalDeposited: currentBalance,
           interestEarned: savingsGoal - currentBalance,
           finalBalance: savingsGoal,
@@ -123,7 +123,7 @@ export default function SavingsCalculator() {
         const totalDeposited = currentBalance + requiredContributionPerPeriod * totalPeriods;
 
         setResults({
-          monthlyContribution: requiredContributionPerPeriod,
+          contributionPerPeriod: requiredContributionPerPeriod,
           totalDeposited: totalDeposited,
           interestEarned: savingsGoal - totalDeposited,
           finalBalance: savingsGoal,
@@ -133,7 +133,6 @@ export default function SavingsCalculator() {
       }
     } else if (mode === "future-balance") {
       // Calculate future balance with current monthly contribution
-      const contributionPerPeriod = monthlyContribution * (12 / periodsPerYear);
       const futureValueOfInitial = currentBalance * Math.pow(1 + ratePerPeriod, totalPeriods);
       const futureValueOfAnnuity =
         contributionPerPeriod * ((Math.pow(1 + ratePerPeriod, totalPeriods) - 1) / ratePerPeriod);
@@ -141,7 +140,7 @@ export default function SavingsCalculator() {
       const totalDeposited = currentBalance + contributionPerPeriod * totalPeriods;
 
       setResults({
-        monthlyContribution: monthlyContribution,
+        contributionPerPeriod: contributionPerPeriod,
         totalDeposited: totalDeposited,
         interestEarned: finalBalance - totalDeposited,
         finalBalance: finalBalance,
@@ -149,10 +148,10 @@ export default function SavingsCalculator() {
       });
       setYearlyBreakdown(calculateYearlyBreakdown(contributionPerPeriod, totalPeriods));
     } else {
-      // Calculate time to reach goal with current monthly contribution
-      if (monthlyContribution <= 0) {
+      // Calculate time to reach goal with current contribution
+      if (contributionPerPeriod <= 0) {
         setResults({
-          monthlyContribution: monthlyContribution,
+          contributionPerPeriod: contributionPerPeriod,
           totalDeposited: currentBalance,
           interestEarned: 0,
           finalBalance: currentBalance,
@@ -162,7 +161,6 @@ export default function SavingsCalculator() {
         return;
       }
 
-      const contributionPerPeriod = monthlyContribution * (12 / periodsPerYear);
       const numerator = savingsGoal + (contributionPerPeriod / ratePerPeriod);
       const denominator = currentBalance + (contributionPerPeriod / ratePerPeriod);
       const periodsToGoal = Math.log(numerator / denominator) / Math.log(1 + ratePerPeriod);
@@ -176,7 +174,7 @@ export default function SavingsCalculator() {
       const totalDeposited = currentBalance + contributionPerPeriod * periodsToGoal;
 
       setResults({
-        monthlyContribution: monthlyContribution,
+        contributionPerPeriod: contributionPerPeriod,
         totalDeposited: totalDeposited,
         interestEarned: finalBalance - totalDeposited,
         finalBalance: finalBalance,
@@ -192,7 +190,7 @@ export default function SavingsCalculator() {
     timeMonths,
     interestRate,
     compounding,
-    monthlyContribution,
+    contributionPerPeriod,
     calculateYearlyBreakdown,
   ]);
 
@@ -348,9 +346,9 @@ export default function SavingsCalculator() {
                   <div className="relative mt-1">
                     <Input
                       type="number"
-                      value={monthlyContribution === 0 ? "" : monthlyContribution}
+                      value={contributionPerPeriod === 0 ? "" : contributionPerPeriod}
                       placeholder="Monthly contribution"
-                      onChange={(e) => setMonthlyContribution(Number(e.target.value))}
+                      onChange={(e) => setcontributionPerPeriod(Number(e.target.value))}
                       className="font-bold block w-full rounded-md shadow-sm py-2 px-3 border pr-10 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
                     />
                      <div className="absolute right-2 top-1/2 -translate-y-1/2 flex flex-col">
@@ -358,7 +356,7 @@ export default function SavingsCalculator() {
                         type="button"
                         tabIndex={-1}
                         aria-label="Increase amount"
-                        onClick={() => setMonthlyContribution((prev) => Math.max(0, prev + 1))}
+                        onClick={() => setcontributionPerPeriod((prev) => Math.max(0, prev + 1))}
                         className="mb-[-5px] hover:text-grey-med-dark focus:outline-none"
                       >
                         <BiSolidUpArrow size={24} />
@@ -367,7 +365,7 @@ export default function SavingsCalculator() {
                         type="button"
                         tabIndex={-1}
                         aria-label="Decrease amount"
-                        onClick={() => setMonthlyContribution((prev) => Math.max(0, prev - 1))}
+                        onClick={() => setcontributionPerPeriod((prev) => Math.max(0, prev - 1))}
                         className="hover:text-grey-med-dark focus:outline-none"
                       >
                         <BiSolidDownArrow size={24} />
@@ -537,7 +535,7 @@ export default function SavingsCalculator() {
                     }`}>
                       {isInvalid(results.totalDeposited)
                       ? "$0"
-                      : `$${results.monthlyContribution.toFixed(2).toLocaleString()}`}
+                      : `$${results.contributionPerPeriod.toFixed(2).toLocaleString()}`}
                   </div>
                 </>
               )}


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
[IFDM-88](https://stanfordits.atlassian.net/browse/IFDM-88): Updates to math

This PR updates the math logic for all three savings calculators to support a new "contribution per period" format, replacing the previous "monthly contributions" approach. It also adds a separate calculation to the monthly savings calculator: if the time to goal is less than one compounding period, the contribution amount is set to the difference between the desired goal and current balance, as interest will not accrue.

- Refactored all savings calculators to use `contributionPerPeriod` instead of `monthlyContribution`.
- Removed redundant calculation where `contributionPerPeriod` was set by multiplying `monthlyContribution` by periods.
- Updated all relevant variable names.
- Added separate calculation to the monthly savings calculator:
  - If the time to goal is less than one compounding period, the contribution amount is set to the difference between the desired goal and current balance, as interest will not accrue.

# Review Tasks

## Setup tasks and/or behavior to test

1. Check out this branch (`IFDM-88--update-match`)
2. Navigate to the savings calculators in the app
3. Verify:
   - All calculators use "contribution per period" logic
   - Monthly Savings calculator shows correct results and handles time to goal < 1 compounding period as described
   - Time to Goal and Future Balance calculators work as expected


[IFDM-88]: https://stanfordits.atlassian.net/browse/IFDM-88?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ