### PR TITLE
Error doc: Compounding frequency calculator

### DIFF
--- a/app/interactives/compounding-frequency-calculator/page.tsx
+++ b/app/interactives/compounding-frequency-calculator/page.tsx
@@ -505,19 +505,19 @@ export default function CompoundInterestCalculator() {
           <Card className="w-full lg:w-1/2 bg-[var(--card-background)] rounded-3xl p-[32px]">
             <CardContent className="p-0">
               <h2 className="text-[20px] font-bold mb-1">
-                Balance after{" "}
+                Balance after
                 {hasError
-                  ? "-"
-                  : `${periods} ${getPeriodText(selectedCompounding, Number(periods))}`}
+                  ? " "
+                  : ` ${periods} ${getPeriodText(selectedCompounding, Number(periods))}`}
               </h2>
               <p className="text-3xl/normal font-bold text-[var(--color-teal)] mb-5 overflow-auto">
                 {hasError ? "-" : balanceStr}
               </p>
               <p className="text-[20px] font-bold mb-1">
-                Interest accrued over{" "}
+                Interest accrued over
                 {hasError
-                  ? "-"
-                  : `${periods} ${getPeriodText(selectedCompounding, Number(periods))}`}
+                  ? ""
+                  : ` ${periods} ${getPeriodText(selectedCompounding, Number(periods))}`}
               </p>
               <p className="text-3xl/normal font-bold text-foreground overflow-auto">
                 {hasError ? "-" : interestStr}

--- a/app/interactives/compounding-frequency-calculator/page.tsx
+++ b/app/interactives/compounding-frequency-calculator/page.tsx
@@ -507,7 +507,7 @@ export default function CompoundInterestCalculator() {
               <h2 className="text-[20px] font-bold mb-1">
                 Balance after
                 {hasError
-                  ? " "
+                  ? ""
                   : ` ${periods} ${getPeriodText(selectedCompounding, Number(periods))}`}
               </h2>
               <p className="text-3xl/normal font-bold text-[var(--color-teal)] mb-5 overflow-auto">


### PR DESCRIPTION
# READY FOR REVIEW
Fixed the display of the dash when there is a blank or error on the calculator. 

# Summary
- There was an extra dash.  

<img width="1209" height="642" alt="Screenshot 2026-06-26 at 2 52 41 PM" src="https://github.com/user-attachments/assets/c1285f7a-3fd1-4c04-a1b3-a8e3142c48b0" />


# Review By (Date)
- When does this need to be reviewed by?

