### PR TITLE
Error doc inflation

### DIFF
--- a/app/interactives/inflation-impact-calculator/page.tsx
+++ b/app/interactives/inflation-impact-calculator/page.tsx
@@ -88,85 +88,96 @@ export default function InflationCalculator() {
           {/* Parameters Panel */}
           <Card>
             <CardContent className="space-y-6">
-              <div className="relative">
+              {/* Initial Price */}
+              <div className="space-y-2">
                 <Label htmlFor="initial-price" className="text-md font-medium">
                   Initial price:
                 </Label>
-                <span
-                  className="absolute left-3 top-8.5 text-[var(--color-symbols)] pointer-events-none"
-                  aria-hidden="true"
-                >
-                  $
-                </span>
-                <Input
-                  id="initial-price"
-                  type="text"
-                  inputMode="numeric"
-                  value={initialPriceDisplay}
-                  onChange={(e) => {
-                    const stripped = e.target.value.replace(/,/g, "");
-                    // Allow only digits and a single decimal point
-                    if (stripped !== "" && !/^\d*\.?\d*$/.test(stripped))
-                      return;
-                    setInitialPriceRaw(stripped);
-                    const num = parseFloat(stripped);
-                    if (!isNaN(num)) {
-                      setInitialPriceDisplay(
-                        num.toLocaleString("en-US", {
-                          maximumFractionDigits: 2,
-                        }),
-                      );
-                    } else {
-                      setInitialPriceDisplay(stripped);
-                    }
-                  }}
-                  onFocus={() => {
-                    // Strip commas so the user can edit cleanly
-                    setInitialPriceDisplay(initialPriceRaw);
-                  }}
-                  onBlur={() => {
-                    const num = parseFloat(initialPriceRaw);
-                    if (!isNaN(num)) {
-                      setInitialPriceDisplay(formatWithCommas(num));
-                    } else {
-                      setInitialPriceDisplay(initialPriceRaw);
-                    }
-                  }}
-                  aria-invalid={priceError !== null}
-                  aria-describedby={
-                    priceError ? "initial-price-error" : undefined
-                  }
-                  className={`bg-[var(--input-background)] text-[var(--input-text)] text-md  w-full rounded-md shadow-sm pl-8 border pr-10 ${
-                    priceError
-                      ? "border-2 border-[var(--color-inline-error)] focus:ring-red-500"
-                      : "bg-[var(--input-border)]"
-                  }`}
-                />
-                {priceErrorMessage && (
-                  <p
-                    id="initial-price-error"
-                    role="alert"
-                    className="text-sm text-[var(--color-inline-error)] mt-1"
+                <div className="relative">
+                  <span
+                    aria-hidden="true"
+                    className="absolute left-3 top-1/2 -translate-y-1/2 text-[var(--color-symbols)] pointer-events-none"
                   >
-                    {priceErrorMessage}
-                  </p>
-                )}
+                    $
+                  </span>
+                  <Input
+                    id="initial-price"
+                    type="text"
+                    inputMode="numeric"
+                    value={initialPriceDisplay}
+                    onChange={(e) => {
+                      const stripped = e.target.value.replace(/,/g, "");
+                      if (stripped !== "" && !/^\d*\.?\d*$/.test(stripped))
+                        return;
+                      setInitialPriceRaw(stripped);
+                      const num = parseFloat(stripped);
+                      if (!isNaN(num)) {
+                        setInitialPriceDisplay(
+                          num.toLocaleString("en-US", {
+                            maximumFractionDigits: 2,
+                          }),
+                        );
+                      } else {
+                        setInitialPriceDisplay(stripped);
+                      }
+                    }}
+                    onFocus={() => {
+                      setInitialPriceDisplay(initialPriceRaw);
+                    }}
+                    onBlur={() => {
+                      const num = parseFloat(initialPriceRaw);
+                      if (!isNaN(num)) {
+                        setInitialPriceDisplay(formatWithCommas(num));
+                      } else {
+                        setInitialPriceDisplay(initialPriceRaw);
+                      }
+                    }}
+                    aria-invalid={priceError !== null}
+                    aria-describedby="initial-price-error"
+                    className={`bg-[var(--input-background)] text-[var(--input-text)] text-md w-full rounded-md shadow-sm pl-7 border pr-10 ${
+                      priceError
+                        ? "border-2 border-[var(--color-inline-error)]"
+                        : "bg-[var(--input-border)]"
+                    }`}
+                  />
+                </div>
+                {/* Always rendered so aria-describedby always resolves */}
+                <p
+                  id="initial-price-error"
+                  role="alert"
+                  className={`text-sm font-semibold mt-1 ${
+                    priceErrorMessage
+                      ? "text-[var(--color-inline-error)]"
+                      : "sr-only"
+                  }`}
+                >
+                  {priceErrorMessage ?? ""}
+                </p>
               </div>
 
               {/* Inflation Rate Slider */}
-              <div className="space-y-3 relative">
+              <div className="space-y-3">
                 <div className="flex sm:items-center space-between gap-2 flex-col sm:flex-row">
-                  <Label className="text-md font-bold">
+                  <Label
+                    htmlFor="inflation-rate-slider"
+                    className="text-md font-bold"
+                  >
                     Annual inflation rate (%):
                   </Label>
                   <Badge
                     className={`${getInflationColor(inflationRate)} text-black font-bold`}
                   >
-                    {inflationRate.toFixed(1)}% -{" "}
+                    {inflationRate.toFixed(1)}%{" "}
                     {getInflationLabel(inflationRate)}
                   </Badge>
                 </div>
                 <CustomSlider
+                  id="inflation-rate-slider"
+                  aria-label="Annual inflation rate"
+                  aria-valuemin={0}
+                  aria-valuemax={15}
+                  aria-valuenow={inflationRate}
+                  aria-valuetext={`${inflationRate.toFixed(1)} percent`}
                   value={[inflationRate]}
                   onValueChange={(value) => setInflationRate(value[0])}
                   max={15}
@@ -174,7 +185,10 @@ export default function InflationCalculator() {
                   step={0.1}
                   className="w-full"
                 />
-                <div className="flex justify-between text-md font-medium font-poppins">
+                <div
+                  className="flex justify-between text-md font-medium font-poppins"
+                  aria-hidden="true"
+                >
                   <span>0%</span>
                   <span>15%</span>
                 </div>
@@ -182,15 +196,28 @@ export default function InflationCalculator() {
 
               {/* Time Period Slider */}
               <div className="space-y-3">
-                <div className="flex items-center">
-                  <Label className="text-md font-bold">
-                    Time period:&nbsp;
+                <div className="flex items-center gap-1">
+                  <Label
+                    htmlFor="time-period-slider"
+                    className="text-md font-bold"
+                  >
+                    Time period:
                   </Label>
-                  <span className="text-md font-semibold flex items-center gap-1">
+                  <span
+                    className="text-md font-semibold"
+                    aria-live="polite"
+                    aria-atomic="true"
+                  >
                     {timePeriod} year{timePeriod !== 1 ? "s" : ""}
                   </span>
                 </div>
                 <CustomSlider
+                  id="time-period-slider"
+                  aria-label="Time period in years"
+                  aria-valuemin={1}
+                  aria-valuemax={50}
+                  aria-valuenow={timePeriod}
+                  aria-valuetext={`${timePeriod} year${timePeriod !== 1 ? "s" : ""}`}
                   value={[timePeriod]}
                   onValueChange={(value) => setTimePeriod(value[0])}
                   max={50}
@@ -199,7 +226,10 @@ export default function InflationCalculator() {
                   className="w-full"
                   rangeClassName="time-period-range bg-lagunita-light"
                 />
-                <div className="flex justify-between text-md font-medium font-poppins">
+                <div
+                  className="flex justify-between text-md font-medium font-poppins"
+                  aria-hidden="true"
+                >
                   <span>1 year</span>
                   <span>50 years</span>
                 </div>
@@ -215,21 +245,20 @@ export default function InflationCalculator() {
               </CardTitle>
             </CardHeader>
             <CardContent>
-              <span className="text-md font-bold font-poppins text-[var(--color-teal)]">
-                After {timePeriod} year{timePeriod !== 1 ? "s" : ""}
-              </span>
-              <div className="pt-4">
-                <div className="rounded-lg">
-                  <div className="innerwrapper">
-                    <div className="flex flex-row mb-1 bg-[var(--results-white-background)] rounded-lg">
-                      <div className="w-[50%] text-md nowrap p-4 font-bold text-black rounded-l-lg bg-grey-med-dark flex items-center">
-                        Future price:
-                      </div>
-                      <div className="w-[50%] bg-[var(--secondary-background)] text-lg-title p-4 rounded-r-lg font-bold overflow-hidden text-ellipsis flex items-center">
-                        {futureValue !== null
-                          ? formatCurrency(futureValue)
-                          : "—"}
-                      </div>
+              <div
+                aria-live="polite"
+                aria-atomic="true"
+              >
+                <span className="text-md font-bold font-poppins text-[var(--color-teal)]">
+                  After {timePeriod} year{timePeriod !== 1 ? "s" : ""}
+                </span>
+                <div className="pt-4 rounded-lg">
+                  <div className="flex flex-row mb-1 bg-[var(--results-white-background)] rounded-lg">
+                    <div className="w-[50%] text-md nowrap p-4 font-bold text-black rounded-l-lg bg-grey-med-dark flex items-center">
+                      Future price:
+                    </div>
+                    <div className="w-[50%] bg-[var(--secondary-background)] text-lg-title p-4 rounded-r-lg font-bold overflow-hidden text-ellipsis flex items-center">
+                      {futureValue !== null ? formatCurrency(futureValue) : "—"}
                     </div>
                   </div>
                 </div>

--- a/app/interactives/inflation-impact-calculator/page.tsx
+++ b/app/interactives/inflation-impact-calculator/page.tsx
@@ -1,98 +1,172 @@
 "use client";
 
-import { useState, useEffect } from "react"
-import { Card, CardContent, CardHeader, CardTitle } from "@/app/ui/components/card"
-import { Input } from "@/app/ui/components/input"
-import { Label } from "@/app/ui/components/label"
-import { CustomSlider } from "@/app/ui/components/slider"
-import { Badge } from "@/app/ui/components/badge"
-import { BiSolidUpArrow, BiSolidDownArrow } from "react-icons/bi";
+import { useState, useEffect } from "react";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/app/ui/components/card";
+import { Input } from "@/app/ui/components/input";
+import { Label } from "@/app/ui/components/label";
+import { CustomSlider } from "@/app/ui/components/slider";
+import { Badge } from "@/app/ui/components/badge";
 import ThemeToggle from "@/app/lib/theme-toggle";
 
-export default function InflationCalculator() {
-  const [initialPrice, setInitialPrice] = useState(100)
-  const [inflationRate, setInflationRate] = useState(3.5)
-  const [timePeriod, setTimePeriod] = useState(10)
-  const [futureValue, setFutureValue] = useState(0)
+const INITIAL_PRICE_MIN = 0.01;
+const INITIAL_PRICE_MAX = 1_000_000_000;
 
-  // Calculate future value based on compound inflation
+type PriceError = "empty" | "range" | null;
+
+function getPriceError(raw: string, numeric: number): PriceError {
+  if (raw === "") return "empty";
+  if (numeric < INITIAL_PRICE_MIN || numeric > INITIAL_PRICE_MAX)
+    return "range";
+  return null;
+}
+
+function formatWithCommas(value: number): string {
+  return value.toLocaleString("en-US", { maximumFractionDigits: 2 });
+}
+
+const formatCurrency = (value: number) =>
+  new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(value);
+
+export default function InflationCalculator() {
+  const [initialPriceRaw, setInitialPriceRaw] = useState("100");
+  const [initialPriceDisplay, setInitialPriceDisplay] = useState("100");
+  const [inflationRate, setInflationRate] = useState(3.5);
+  const [timePeriod, setTimePeriod] = useState(10);
+  const [futureValue, setFutureValue] = useState<number | null>(0);
+
+  const numericPrice = parseFloat(initialPriceRaw);
+  const priceError: PriceError = getPriceError(initialPriceRaw, numericPrice);
+  const isValid = priceError === null && !isNaN(numericPrice);
+
   useEffect(() => {
-    const future = initialPrice * Math.pow(1 + inflationRate / 100, timePeriod)
-    setFutureValue(future)
-  }, [initialPrice, inflationRate, timePeriod])
+    if (!isValid) {
+      setFutureValue(null);
+      return;
+    }
+    const future = numericPrice * Math.pow(1 + inflationRate / 100, timePeriod);
+    setFutureValue(future);
+  }, [initialPriceRaw, inflationRate, timePeriod, isValid, numericPrice]);
 
   const getInflationLabel = (rate: number) => {
-    if (rate <= 2.9) return "Low"
-    if (rate <= 6) return "Moderate"
-    if (rate <= 10) return "High"
-    return "Very high"
-  }
+    if (rate <= 2.9) return "Low";
+    if (rate <= 6) return "Moderate";
+    if (rate <= 10) return "High";
+    return "Very high";
+  };
 
   const getInflationColor = (rate: number) => {
-    if (rate <= 2.9) return "bg-badge-green" // Green
-    if (rate <= 6) return "bg-badge-yellow" // Yellow
-    if (rate <= 10) return "bg-badge-orange" // Orange
-    return "bg-badge-red" // Red
-  }
+    if (rate <= 2.9) return "bg-badge-green";
+    if (rate <= 6) return "bg-badge-yellow";
+    if (rate <= 10) return "bg-badge-orange";
+    return "bg-badge-red";
+  };
+
+  const priceErrorMessage =
+    priceError === "empty"
+      ? "Enter an initial amount to see the impact of inflation over time."
+      : priceError === "range"
+        ? "Enter an amount between $0.01 and $1,000,000,000."
+        : null;
 
   return (
     <div className="p-6 max-w-5xl mx-auto">
       <ThemeToggle />
       <div className="max-w-6xl mx-auto">
-        {/* Header */}
         <h1 className="sr-only mb-2">Inflation Impact Calculator</h1>
 
         <div className="grid md:grid-cols-2 gap-8">
           {/* Parameters Panel */}
           <Card>
             <CardContent className="space-y-6">
-              {/* Future Value Input */}
-              <div className="space-y-2 relative">
+              <div className="relative">
                 <Label htmlFor="initial-price" className="text-md font-medium">
-                  Initial price ($):
+                  Initial price:
                 </Label>
-
+                <span
+                  className="absolute left-3 top-8.5 text-[var(--color-symbols)] pointer-events-none"
+                  aria-hidden="true"
+                >
+                  $
+                </span>
                 <Input
                   id="initial-price"
-                  type="number"
-                  value={initialPrice === 0 ? "" : initialPrice}
-                  onChange={(e) => setInitialPrice(Number(e.target.value) || 0)}
-                  className="bg-[var(--input-background)] text-[var(--input-text)] bg-[var(--input-border)] text-md font-bold block w-full rounded-md shadow-sm py-2 px-3 border pr-10 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
-                  min="1"
-                  max="1000000"
+                  type="text"
+                  inputMode="numeric"
+                  value={initialPriceDisplay}
+                  onChange={(e) => {
+                    const stripped = e.target.value.replace(/,/g, "");
+                    // Allow only digits and a single decimal point
+                    if (stripped !== "" && !/^\d*\.?\d*$/.test(stripped))
+                      return;
+                    setInitialPriceRaw(stripped);
+                    const num = parseFloat(stripped);
+                    if (!isNaN(num)) {
+                      setInitialPriceDisplay(
+                        num.toLocaleString("en-US", {
+                          maximumFractionDigits: 2,
+                        }),
+                      );
+                    } else {
+                      setInitialPriceDisplay(stripped);
+                    }
+                  }}
+                  onFocus={() => {
+                    // Strip commas so the user can edit cleanly
+                    setInitialPriceDisplay(initialPriceRaw);
+                  }}
+                  onBlur={() => {
+                    const num = parseFloat(initialPriceRaw);
+                    if (!isNaN(num)) {
+                      setInitialPriceDisplay(formatWithCommas(num));
+                    } else {
+                      setInitialPriceDisplay(initialPriceRaw);
+                    }
+                  }}
+                  aria-invalid={priceError !== null}
+                  aria-describedby={
+                    priceError ? "initial-price-error" : undefined
+                  }
+                  className={`bg-[var(--input-background)] text-[var(--input-text)] text-md  w-full rounded-md shadow-sm pl-8 border pr-10 ${
+                    priceError
+                      ? "border-2 border-[var(--color-inline-error)] focus:ring-red-500"
+                      : "bg-[var(--input-border)]"
+                  }`}
                 />
-                <div className="absolute right-2 top-[38%] flex flex-col">
-                  {/* Increment/Decrement buttons for Future Value */}
-                  <button
-                    type="button"
-                    tabIndex={-1}
-                    aria-label="Increase amount"
-                    onClick={() => setInitialPrice((prev) => prev + 1)}
-                    className="mb-[-5px] hover:text-grey-med-dark focus:outline-none"
+                {priceErrorMessage && (
+                  <p
+                    id="initial-price-error"
+                    role="alert"
+                    className="text-sm text-[var(--color-inline-error)] mt-1"
                   >
-                    <BiSolidUpArrow size={24} />
-                  </button>
-                  <button
-                    type="button"
-                    tabIndex={-1}
-                    aria-label="Decrease amount"
-                    onClick={() => setInitialPrice((prev) => Math.max(1, prev - 1))}
-                    className="hover:text-grey-med-dark focus:outline-none"
-                  >
-                    <BiSolidDownArrow size={24} />
-                  </button>
-                </div>
+                    {priceErrorMessage}
+                  </p>
+                )}
               </div>
 
-              {/* Interest Rate Slider */}
+              {/* Inflation Rate Slider */}
               <div className="space-y-3 relative">
-                  <div className="flex sm:items-center space-between gap-2 flex-col sm:flex-row">
-                    <Label className="text-md font-bold">Annual inflation rate (%):</Label>
-                    <Badge className={`${getInflationColor(inflationRate)} text-black font-bold`}>
-                      {inflationRate.toFixed(1)}% - {getInflationLabel(inflationRate)}
-                    </Badge>
-                  </div>
-                 <CustomSlider
+                <div className="flex sm:items-center space-between gap-2 flex-col sm:flex-row">
+                  <Label className="text-md font-bold">
+                    Annual inflation rate (%):
+                  </Label>
+                  <Badge
+                    className={`${getInflationColor(inflationRate)} text-black font-bold`}
+                  >
+                    {inflationRate.toFixed(1)}% -{" "}
+                    {getInflationLabel(inflationRate)}
+                  </Badge>
+                </div>
+                <CustomSlider
                   value={[inflationRate]}
                   onValueChange={(value) => setInflationRate(value[0])}
                   max={15}
@@ -100,7 +174,7 @@ export default function InflationCalculator() {
                   step={0.1}
                   className="w-full"
                 />
-                <div className="flex justify-between text-md  font-medium font-poppins">
+                <div className="flex justify-between text-md font-medium font-poppins">
                   <span>0%</span>
                   <span>15%</span>
                 </div>
@@ -109,7 +183,9 @@ export default function InflationCalculator() {
               {/* Time Period Slider */}
               <div className="space-y-3">
                 <div className="flex items-center">
-                  <Label className="text-md font-bold">Time period:&nbsp;</Label>
+                  <Label className="text-md font-bold">
+                    Time period:&nbsp;
+                  </Label>
                   <span className="text-md font-semibold flex items-center gap-1">
                     {timePeriod} year{timePeriod !== 1 ? "s" : ""}
                   </span>
@@ -131,31 +207,31 @@ export default function InflationCalculator() {
             </CardContent>
           </Card>
 
-          {/* Present Value Calculation Panel */}
+          {/* Results Panel */}
           <Card className="rounded-3xl p-[32px] bg-[var(--card-background)]">
             <CardHeader className="py-1">
-              <CardTitle className="py-1 font-bold font-poppins">Results:</CardTitle>
+              <CardTitle className="py-1 font-bold font-poppins">
+                Results:
+              </CardTitle>
             </CardHeader>
-            <CardContent className="">
-              {/* Main Result */}
-             <span className="text-md font-bold font-poppins text-lagunita">
+            <CardContent>
+              <span className="text-md font-bold font-poppins text-[var(--color-teal)]">
                 After {timePeriod} year{timePeriod !== 1 ? "s" : ""}
               </span>
-              {/* Calculation Breakdown */}
               <div className="pt-4">
-                {/* Results section */}
                 <div className="rounded-lg">
-                    <div className="innerwrapper">
-                      <div className="flex flex-row mb-1 bg-[var(--results-white-background)] rounded-lg">
-                        <div className="w-[50%] text-md nowrap p-4 font-bold text-black rounded-l-lg bg-grey-med-dark flex items-center">
-                          Future price:
-                        </div>
-                        <div className="w-[50%] bg-[var(--secondary-background)] text-lg-title p-4 rounded-r-lg font-bold overflow-hidden text-ellipsis flex items-center">
-                          {`$${futureValue.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`}
-                        </div>
+                  <div className="innerwrapper">
+                    <div className="flex flex-row mb-1 bg-[var(--results-white-background)] rounded-lg">
+                      <div className="w-[50%] text-md nowrap p-4 font-bold text-black rounded-l-lg bg-grey-med-dark flex items-center">
+                        Future price:
+                      </div>
+                      <div className="w-[50%] bg-[var(--secondary-background)] text-lg-title p-4 rounded-r-lg font-bold overflow-hidden text-ellipsis flex items-center">
+                        {futureValue !== null
+                          ? formatCurrency(futureValue)
+                          : "—"}
                       </div>
                     </div>
-                  {/* Wrapper section ends */}
+                  </div>
                 </div>
               </div>
             </CardContent>
@@ -163,5 +239,5 @@ export default function InflationCalculator() {
         </div>
       </div>
     </div>
-  )
+  );
 }


### PR DESCRIPTION
# READY FOR REVIEW
Notes: I added the errors in the error doc. I also updated some of the UI to match the new styles we are doing. I brought up some of the consistency issues. 

# Summary
**Inflation Impact Calculator -- validation, formatting, and accessibility**

**Validation**
- Added empty field error: blocks calculation and shows "Enter an initial amount to see the impact of inflation over time."
- Added range error for values outside $0.01 and $1,000,000,000: blocks calculation and shows "Enter an amount between $0.01 and $1,000,000,000."
- Results panel shows "—" when the field is empty or out of range
- Sliders retain their existing enforced ranges; no changes needed there

**Formatting**
- Initial price input now displays comma-formatted values (e.g. 1,000,000)
- Input strips commas on focus for clean editing and re-applies them on blur
- Results panel uses `formatCurrency` via `Intl.NumberFormat` for consistent USD output, matching the PV calculator pattern

**Accessibility**
- Error message `<p>` is always rendered and referenced via `aria-describedby`; hidden with `sr-only` when no error is active, visible when one is
- `aria-invalid` set on the input when an error is present
- Results panel wrapped in `aria-live="polite" aria-atomic="true"` so screen readers announce updates
- Both sliders have `aria-label`, `aria-valuemin`, `aria-valuemax`, `aria-valuenow`, and `aria-valuetext`
- Time period display span has `aria-live="polite"` so the year count is announced as the slider moves
- Slider min/max label spans marked `aria-hidden="true"` since the range is already conveyed via ARIA attributes
- `$` symbol positioned with `top-1/2 -translate-y-1/2` replacing the non-standard `top-8.5`