### PR TITLE
Mortgage Calc v2 error word doc

### DIFF
--- a/app/interactives/mortgage-calculator-v2/page.tsx
+++ b/app/interactives/mortgage-calculator-v2/page.tsx
@@ -323,7 +323,7 @@ export default function MortgageCalculator() {
   const showPaymentResults = mode === 'payment' && !v.paymentBlocking;
   const affordCoral = mode === 'afford' && (v.affordWrongValue || limitReached);
   const paymentCoral = mode === 'payment' && v.paymentWrongValue;
-  const emptyResultsString = "Enter values to see your estimate";
+  const emptyResultsString = "Enter values to see your estimate.";
   const fixFieldsString = "Please fix the highlighted fields to see your estimate.";
   const limitString = "That payment is too high to calculate. Try a lower amount to see your estimate.";
 
@@ -353,15 +353,15 @@ export default function MortgageCalculator() {
   const CoralCard = ({ message }: { message: string }) => (
     <div
       role="alert"
-      className="min-h-[28rem] flex items-center justify-center rounded-3xl border border-red-200 bg-red-50 px-6 py-8 text-center text-red-900"
+      className="min-h-[28rem] text-center text-[var(--color-inline-error)]"
     >
       <p className="text-lg font-semibold">{message}</p>
     </div>
   );
 
   const EmptyPanel = () => (
-    <div className="min-h-[28rem] flex items-center justify-center">
-      <p className="text-lg font-bold text-gray-500 italic">{emptyResultsString}</p>
+    <div className="min-h-[28rem] text-center">
+      <p className="text-lg font-bold">{emptyResultsString}</p>
     </div>
   );
 

--- a/app/interactives/mortgage-calculator-v2/page.tsx
+++ b/app/interactives/mortgage-calculator-v2/page.tsx
@@ -1,13 +1,63 @@
 "use client"
 
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import ThemeToggle from "@/app/lib/theme-toggle";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/app/ui/components/tabs";
 import { Card, CardContent, CardHeader, CardTitle } from "@/app/ui/components/card";
 import InfoPopover from "@/app/ui/components/popover";
 
+/* ── Limits & ranges (see feedback doc, June 2026) ───────────────────────── */
+const MONTHLY_PAYMENT_MIN = 1;
+const MONTHLY_PAYMENT_MAX = 1_000_000;
+const HOME_PRICE_MIN = 1;
+const HOME_PRICE_MAX = 1_000_000_000;
+const DP_DOLLAR_MAX_AFFORD = 1_000_000_000;
+const RATE_MIN = 0;
+const RATE_MAX = 20;
+const DP_PERCENT_MIN = 0;
+const DP_PERCENT_MAX = 99.9;
+const TAX_RATE_MAX = 10;
+const INS_RATE_MAX = 10;
+const RELATIVE_CAP = 0.10; // property tax / insurance $ cap = 10% of home price
+const HOA_MIN = 0;
+const HOA_MAX = 20_000;
+const HOME_PRICE_DISPLAY_CEILING = 1_000_000_000_000; // #19 backstop guard
+
+type Mode = 'afford' | 'payment';
+type Toggle = 'percentage' | 'dollar';
+
+const EMPTY_RESULTS: Results = {
+  homePrice: 0, downPayment: 0, loanAmount: 0, monthlyMortgage: 0,
+  monthlyTax: 0, monthlyInsurance: 0, totalMonthly: 0, hoaDues: 0,
+  totalMonthlyHousingCost: 0,
+};
+
+interface Results {
+  homePrice: number;
+  downPayment: number;
+  loanAmount: number;
+  monthlyMortgage: number;
+  monthlyTax: number;
+  monthlyInsurance: number;
+  totalMonthly: number;
+  hoaDues: number;
+  totalMonthlyHousingCost: number;
+}
+
+function FieldError({ id, children }: { id: string; children: React.ReactNode }) {
+  return (
+    <p
+      id={id}
+      role="alert"
+      className="mt-1 text-sm font-semibold text-[var(--color-inline-error)]"
+    >
+      {children}
+    </p>
+  );
+}
+
 export default function MortgageCalculator() {
-  const [mode, setMode] = useState('afford');
+  const [mode, setMode] = useState<Mode>('afford');
   const [monthlyPayment, setMonthlyPayment] = useState("");
   const [homePrice, setHomePrice] = useState("");
   const [downPaymentPercent, setDownPaymentPercent] = useState(20);
@@ -16,45 +66,153 @@ export default function MortgageCalculator() {
   const [propertyTaxPercent, setPropertyTaxPercent] = useState(1.25);
   const [homeInsurancePercent, setHomeInsurancePercent] = useState(0.35);
   const [hoaDues, setHoaDues] = useState("");
-  const [downPaymentMode, setDownPaymentMode] = useState('percentage');
+  const [downPaymentMode, setDownPaymentMode] = useState<Toggle>('percentage');
   const [downPaymentAmount, setDownPaymentAmount] = useState(0);
   const [downPaymentPercentInput, setDownPaymentPercentInput] = useState('20');
   const [downPaymentAmountInput, setDownPaymentAmountInput] = useState('0');
-  const [propertyTaxMode, setPropertyTaxMode] = useState('percentage');
+  const [propertyTaxMode, setPropertyTaxMode] = useState<Toggle>('percentage');
   const [propertyTaxAmount, setPropertyTaxAmount] = useState(0);
-  const [homeInsuranceMode, setHomeInsuranceMode] = useState('percentage');
+  const [homeInsuranceMode, setHomeInsuranceMode] = useState<Toggle>('percentage');
   const [homeInsuranceAmount, setHomeInsuranceAmount] = useState(0);
   const [calculatedHomePrice, setCalculatedHomePrice] = useState(0);
-  const [showRateError, setShowRateError] = useState(false);
+  const [limitReached, setLimitReached] = useState(false);
 
-  const [results, setResults] = useState({
-    homePrice: 0,
-    downPayment: 0,
-    loanAmount: 0,
-    monthlyMortgage: 0,
-    monthlyTax: 0,
-    monthlyInsurance: 0,
-    totalMonthly: 0,
-    hoaDues: 0,
-    totalMonthlyHousingCost: 0
+  // Required-field "please enter…" messages only surface after the field is
+  // touched-then-left, per Rachel's note. Range errors surface immediately.
+  const [touched, setTouched] = useState({
+    monthlyPayment: false,
+    homePrice: false,
+    interestRate: false,
   });
 
+  const [results, setResults] = useState<Results>(EMPTY_RESULTS);
+
+  const clampPercent = (value: number) => Math.max(0, Math.min(100, value));
+  const clampNonNegativeNumber = (value: number) => Math.max(0, Number(value) || 0);
+
+  /* ── Validation ────────────────────────────────────────────────────────
+     One source of truth for messages + blocking flags, used by both the calc
+     and the render so the output can never show stale numbers next to an error. */
+  const v = useMemo(() => {
+    const rateNum = Number(interestRate);
+    const paymentNum = Number(monthlyPayment);
+    const priceNum = Number(homePrice);
+    const hoaNum = Number(hoaDues);
+    const activePrice = mode === 'afford' ? calculatedHomePrice : priceNum;
+
+    // Interest rate (shared) — 0–20 inclusive
+    const rateEmpty = interestRate === "";
+    const rateRangeBad = !rateEmpty && (rateNum < RATE_MIN || rateNum > RATE_MAX);
+    let rateMsg = "";
+    if (rateEmpty && touched.interestRate) rateMsg = "Please enter an interest rate.";
+    else if (rateRangeBad) rateMsg = "Please enter an interest rate between 0 and 20%.";
+
+    // Monthly payment (Tab 1) — 1–1,000,000 inclusive, 0 below min
+    const paymentEmpty = monthlyPayment === "";
+    const paymentRangeBad = !paymentEmpty && (paymentNum < MONTHLY_PAYMENT_MIN || paymentNum > MONTHLY_PAYMENT_MAX);
+    let paymentMsg = "";
+    if (paymentEmpty && touched.monthlyPayment) paymentMsg = "Please enter your monthly mortgage payment.";
+    else if (paymentRangeBad) paymentMsg = "Enter an amount between $1 and $1,000,000. Amounts beyond this are unusual.";
+
+    // Home price (Tab 2) — 1–1,000,000,000 inclusive
+    const priceEmpty = homePrice === "";
+    const priceRangeBad = !priceEmpty && (priceNum < HOME_PRICE_MIN || priceNum > HOME_PRICE_MAX);
+    let priceMsg = "";
+    if (priceEmpty && touched.homePrice) priceMsg = "Please enter the purchase price of the home.";
+    else if (priceRangeBad) priceMsg = "Enter an amount between $1 and $1,000,000,000.";
+
+    // Down payment
+    let dpMsg = "";
+    let dpBad = false;
+    if (downPaymentMode === 'percentage') {
+      dpBad = downPaymentPercent < DP_PERCENT_MIN || downPaymentPercent > DP_PERCENT_MAX;
+      if (dpBad) dpMsg = "Enter a percentage between 0 - 99.9%.";
+    } else if (mode === 'afford') {
+      // Tab 1: absolute ceiling (no home-price input to clamp against)
+      dpBad = downPaymentAmount < 0 || downPaymentAmount > DP_DOLLAR_MAX_AFFORD;
+      if (dpBad) dpMsg = "Enter an amount between 0 - 1,000,000,000.";
+    } else {
+      // Tab 2: relational against home price
+      if (downPaymentAmount < 0) {
+        dpBad = true;
+        dpMsg = "Down payment cannot be negative. Enter 0 if no down payment is planned.";
+      } else if (!priceEmpty && priceNum > 0 && downPaymentAmount >= priceNum) {
+        dpBad = true;
+        dpMsg = "Your down payment can't exceed the home price. Try lowering it.";
+      }
+    }
+
+    // Property taxes
+    let taxMsg = "";
+    let taxBad = false;
+    if (propertyTaxMode === 'percentage') {
+      taxBad = propertyTaxPercent < 0 || propertyTaxPercent > TAX_RATE_MAX;
+      if (taxBad) taxMsg = "Enter a property tax rate between 0 and 10%. Rates beyond this are unusual.";
+    } else if (activePrice > 0 && propertyTaxAmount > RELATIVE_CAP * activePrice) {
+      taxBad = true;
+      taxMsg = "Enter a property tax amount between 0 and 10% of the home price. Amounts beyond this are unusual.";
+    }
+
+    // Homeowners insurance
+    let insMsg = "";
+    let insBad = false;
+    if (homeInsuranceMode === 'percentage') {
+      insBad = homeInsurancePercent < 0 || homeInsurancePercent > INS_RATE_MAX;
+      if (insBad) insMsg = "Enter a homeowners insurance rate between 0 and 10%. Rates beyond this are unusual.";
+    } else if (activePrice > 0 && homeInsuranceAmount > RELATIVE_CAP * activePrice) {
+      insBad = true;
+      insMsg = "Enter a homeowners insurance amount between 0 and 10% of the home price. Amounts beyond this are unusual.";
+    }
+
+    // HOA dues — 0–20,000 inclusive
+    const hoaBad = hoaDues !== "" && (hoaNum < HOA_MIN || hoaNum > HOA_MAX);
+    const hoaMsg = hoaBad ? "Enter an amount between $0 and $20,000." : "";
+
+    // Blocking = anything that must stop the calc (includes empties)
+    const rateBlock = rateEmpty || rateRangeBad;
+    const paymentBlock = paymentEmpty || paymentRangeBad;
+    const priceBlock = priceEmpty || priceRangeBad;
+
+    const affordBlocking = paymentBlock || rateBlock || dpBad || taxBad || insBad || hoaBad;
+    const paymentBlocking = priceBlock || rateBlock || dpBad || taxBad || insBad || hoaBad;
+
+    // Wrong-value = a real bad value is present (drives the coral card).
+    // Empties alone leave the panel blank instead.
+    const affordWrongValue = paymentRangeBad || rateRangeBad || dpBad || taxBad || insBad || hoaBad;
+    const paymentWrongValue = priceRangeBad || rateRangeBad || dpBad || taxBad || insBad || hoaBad;
+
+    return {
+      rateMsg, paymentMsg, priceMsg, dpMsg, taxMsg, insMsg, hoaMsg,
+      affordBlocking, paymentBlocking, affordWrongValue, paymentWrongValue,
+    };
+  }, [
+    mode, monthlyPayment, homePrice, interestRate, downPaymentMode,
+    downPaymentPercent, downPaymentAmount, propertyTaxMode, propertyTaxPercent,
+    propertyTaxAmount, homeInsuranceMode, homeInsurancePercent,
+    homeInsuranceAmount, hoaDues, calculatedHomePrice, touched,
+  ]);
+
   const calculateMortgage = useCallback(() => {
-    const r = (Number(interestRate) / 100 / 12);
+    const rateNum = Number(interestRate);
+    const r = rateNum / 100 / 12;
     const n = loanTerm * 12;
     const hoaDuesNum = Number(hoaDues) || 0;
 
+    const blank = () => {
+      setResults(EMPTY_RESULTS);
+      setCalculatedHomePrice(0);
+    };
+
     if (mode === 'afford') {
-      const paymentAmount = Math.max(0, Number(monthlyPayment));
-      const interestRateValue = Number(interestRate);
+      if (v.affordBlocking) { setLimitReached(false); blank(); return; }
 
-      if (paymentAmount <= 0 || interestRateValue <= 0) {
-        setResults({ homePrice: 0, downPayment: 0, loanAmount: 0, monthlyMortgage: 0, monthlyTax: 0, monthlyInsurance: 0, totalMonthly: 0, hoaDues: 0, totalMonthlyHousingCost: 0 });
-        setCalculatedHomePrice(0);
-        return;
-      }
+      const paymentAmount = Number(monthlyPayment);
 
-      const loanAmount = paymentAmount * ((Math.pow(1 + r, n) - 1) / (r * Math.pow(1 + r, n)));
+      // 0% interest is now valid (inclusive), so guard the divide-by-zero.
+      const loanAmount = r === 0
+        ? paymentAmount * n
+        : paymentAmount * ((Math.pow(1 + r, n) - 1) / (r * Math.pow(1 + r, n)));
+
       let computedHomePrice: number;
       let downPayment: number;
 
@@ -68,15 +226,17 @@ export default function MortgageCalculator() {
         }
       } else {
         const safeDownPaymentPercent = clampPercent(downPaymentPercent);
-        if (safeDownPaymentPercent >= 100) {
-          setResults({ homePrice: 0, downPayment: 0, loanAmount: 0, monthlyMortgage: 0, monthlyTax: 0, monthlyInsurance: 0, totalMonthly: 0, hoaDues: 0, totalMonthlyHousingCost: 0 });
-          setCalculatedHomePrice(0);
-          return;
-        }
         computedHomePrice = loanAmount / (1 - safeDownPaymentPercent / 100);
         downPayment = computedHomePrice * (safeDownPaymentPercent / 100);
       }
 
+      // #19 backstop: if the result runs away, show the limit message.
+      if (!isFinite(computedHomePrice) || computedHomePrice > HOME_PRICE_DISPLAY_CEILING) {
+        setLimitReached(true);
+        blank();
+        return;
+      }
+      setLimitReached(false);
       setCalculatedHomePrice(computedHomePrice);
 
       const monthlyTax = propertyTaxMode === 'percentage'
@@ -87,59 +247,63 @@ export default function MortgageCalculator() {
         ? (computedHomePrice * (homeInsurancePercent / 100)) / 12
         : homeInsuranceAmount / 12;
 
-      const totalMonthly = Number(monthlyPayment) + monthlyTax + monthlyInsurance + hoaDuesNum;
+      const totalMonthly = paymentAmount + monthlyTax + monthlyInsurance + hoaDuesNum;
 
       setResults({
         homePrice: Math.round(computedHomePrice),
         downPayment: Math.round(downPayment),
         loanAmount: Math.round(loanAmount),
-        monthlyMortgage: Number(Math.round(Number(monthlyPayment))),
+        monthlyMortgage: Math.round(paymentAmount),
         monthlyTax: Math.round(monthlyTax),
         monthlyInsurance: Math.round(monthlyInsurance),
-        totalMonthly: Math.round(Number(totalMonthly)),
+        totalMonthly: Math.round(totalMonthly),
         hoaDues: Math.round(hoaDuesNum),
-        totalMonthlyHousingCost: Math.round(Number(totalMonthly))
+        totalMonthlyHousingCost: Math.round(totalMonthly),
       });
-    } else if (mode === 'payment') {
-      const homePriceAmount = Math.max(0, Number(homePrice));
-      const safeDownPaymentPercent = clampPercent(downPaymentPercent);
-      const downPayment = homePriceAmount * (safeDownPaymentPercent / 100);
-      const loanAmount = clampNonNegativeNumber(homePriceAmount - downPayment);
+    } else {
+      setLimitReached(false);
+      if (v.paymentBlocking) { blank(); return; }
 
-      if (homePriceAmount <= 0 || safeDownPaymentPercent >= 100) {
-        setResults({ homePrice: 0, downPayment: 0, loanAmount: 0, monthlyMortgage: 0, monthlyTax: 0, monthlyInsurance: 0, totalMonthly: 0, hoaDues: 0, totalMonthlyHousingCost: 0 });
-        return;
-      }
+      const homePriceAmount = Number(homePrice);
+      const downPayment = downPaymentMode === 'dollar'
+        ? downPaymentAmount
+        : homePriceAmount * (clampPercent(downPaymentPercent) / 100);
+      const loanAmount = Math.max(0, homePriceAmount - downPayment);
 
-      const monthlyMortgage = loanAmount * (r * Math.pow(1 + r, n)) / (Math.pow(1 + r, n) - 1);
-      if (!isFinite(monthlyMortgage) || monthlyMortgage < loanAmount * r) {
-        setResults({ homePrice: 0, downPayment: 0, loanAmount: 0, monthlyMortgage: 0, monthlyTax: 0, monthlyInsurance: 0, totalMonthly: 0, hoaDues: 0, totalMonthlyHousingCost: 0 });
-        return;
-      }
+      const monthlyMortgage = r === 0
+        ? loanAmount / n
+        : loanAmount * (r * Math.pow(1 + r, n)) / (Math.pow(1 + r, n) - 1);
+
+      if (!isFinite(monthlyMortgage)) { blank(); return; }
 
       const monthlyTax = propertyTaxMode === 'percentage'
-        ? (Number(homePrice) * (propertyTaxPercent / 100)) / 12
+        ? (homePriceAmount * (propertyTaxPercent / 100)) / 12
         : propertyTaxAmount / 12;
 
       const monthlyInsurance = homeInsuranceMode === 'percentage'
-        ? (Number(homePrice) * (homeInsurancePercent / 100)) / 12
+        ? (homePriceAmount * (homeInsurancePercent / 100)) / 12
         : homeInsuranceAmount / 12;
 
       const totalMonthly = monthlyMortgage + monthlyTax + monthlyInsurance + hoaDuesNum;
 
       setResults({
-        homePrice: Math.round(Number(homePrice)),
+        homePrice: Math.round(homePriceAmount),
         downPayment: Math.round(downPayment),
         loanAmount: Math.round(loanAmount),
         monthlyMortgage: Math.round(monthlyMortgage),
         monthlyTax: Math.round(monthlyTax),
         monthlyInsurance: Math.round(monthlyInsurance),
-        totalMonthly: Math.round(Number(totalMonthly)),
+        totalMonthly: Math.round(totalMonthly),
         hoaDues: Math.round(hoaDuesNum),
-        totalMonthlyHousingCost: Math.round(Number(totalMonthly))
+        totalMonthlyHousingCost: Math.round(totalMonthly),
       });
     }
-  }, [mode, monthlyPayment, homePrice, downPaymentPercent, downPaymentAmount, downPaymentMode, interestRate, loanTerm, propertyTaxPercent, propertyTaxMode, propertyTaxAmount, homeInsurancePercent, homeInsuranceMode, homeInsuranceAmount, hoaDues]);
+  }, [
+    mode, monthlyPayment, homePrice, downPaymentPercent, downPaymentAmount,
+    downPaymentMode, interestRate, loanTerm, propertyTaxPercent, propertyTaxMode,
+    propertyTaxAmount, homeInsurancePercent, homeInsuranceMode,
+    homeInsuranceAmount, hoaDues, v,
+  ]);
 
   useEffect(() => {
     calculateMortgage();
@@ -155,28 +319,13 @@ export default function MortgageCalculator() {
     }).format(value);
   };
 
-  const clampPercent = (value: number) => Math.max(0, Math.min(100, value));
-  const clampNonNegativeNumber = (value: number) => Math.max(0, Number(value) || 0);
-  const clampDownPaymentAmount = (amount: number, price: number) => Math.max(0, Math.min(amount, price));
-
-  const emptyResultsString = "Enter values to see your estimate"
-  const validationErrorMessage = "Your inputs are not valid for this scenario. Try lowering the down payment or increasing the home price."
-  const hasValidationError = (
-    Number(monthlyPayment) < 0 ||
-    Number(homePrice) < 0 ||
-    Number(interestRate) < 0 ||
-    Number(propertyTaxPercent) < 0 ||
-    Number(homeInsurancePercent) < 0 ||
-    Number(propertyTaxAmount) < 0 ||
-    Number(homeInsuranceAmount) < 0 ||
-    Number(hoaDues) < 0 ||
-    downPaymentPercent < 0 ||
-    downPaymentPercent >= 100 ||
-    downPaymentAmount < 0 ||
-    (Number(homePrice) > 0 && downPaymentAmount > Number(homePrice))
-  );
-  const showAffordResults = mode === 'afford' && Number(monthlyPayment) > 0 && Number(interestRate) > 0 && downPaymentPercent < 100;
-  const showPaymentResults = mode === 'payment' && Number(homePrice) > 0 && interestRate !== "" && downPaymentPercent < 100;
+  const showAffordResults = mode === 'afford' && !v.affordBlocking && !limitReached;
+  const showPaymentResults = mode === 'payment' && !v.paymentBlocking;
+  const affordCoral = mode === 'afford' && (v.affordWrongValue || limitReached);
+  const paymentCoral = mode === 'payment' && v.paymentWrongValue;
+  const emptyResultsString = "Enter values to see your estimate";
+  const fixFieldsString = "Please fix the highlighted fields to see your estimate.";
+  const limitString = "That payment is too high to calculate. Try a lower amount to see your estimate.";
 
   const handleReset = () => {
     setMonthlyPayment('');
@@ -196,9 +345,95 @@ export default function MortgageCalculator() {
     setHoaDues('');
     setDownPaymentMode('percentage');
     setCalculatedHomePrice(0);
-    setShowRateError(false);
-    setResults({ homePrice: 0, downPayment: 0, loanAmount: 0, monthlyMortgage: 0, monthlyTax: 0, monthlyInsurance: 0, totalMonthly: 0, hoaDues: 0, totalMonthlyHousingCost: 0 });
-  }
+    setLimitReached(false);
+    setTouched({ monthlyPayment: false, homePrice: false, interestRate: false });
+    setResults(EMPTY_RESULTS);
+  };
+
+  const CoralCard = ({ message }: { message: string }) => (
+    <div
+      role="alert"
+      className="min-h-[28rem] flex items-center justify-center rounded-3xl border border-red-200 bg-red-50 px-6 py-8 text-center text-red-900"
+    >
+      <p className="text-lg font-semibold">{message}</p>
+    </div>
+  );
+
+  const EmptyPanel = () => (
+    <div className="min-h-[28rem] flex items-center justify-center">
+      <p className="text-lg font-bold text-gray-500 italic">{emptyResultsString}</p>
+    </div>
+  );
+
+  const ResultsBody = ({ headline }: { headline: string }) => (
+    <div className="rounded-lg">
+      <div className="innerwrapper">
+        <div className="flex flex-col sm:flex-row mb-1 sm:bg-[var(--results-white-background)] rounded-lg">
+          <div className="w-full sm:w-[50%] text-md p-4 font-bold text-black rounded-lg sm:rounded-l-lg sm:rounded-r-none bg-grey-med-dark items-center">
+            Down payment:
+          </div>
+          <div className="w-full sm:w-[50%] text-lg-title p-4 self-center rounded-lg sm:rounded-r-lg font-bold text-[var(--foreground)] overflow-hidden text-ellipsis bg-[var(--secondary-background)]">
+            {formatCurrency(results.downPayment || 0)}
+          </div>
+        </div>
+        <div className="flex flex-col sm:flex-row mb-1 sm:bg-[var(--results-white-background)] rounded-lg">
+          <div className="w-full sm:w-[50%] text-md p-4 text-black font-bold rounded-lg sm:rounded-l-lg sm:rounded-r-none bg-grey-med-dark">
+            Loan amount:
+          </div>
+          <div className="w-full sm:w-[50%] text-lg-title p-4 self-center rounded-lg sm:rounded-r-lg text-palo-verde font-bold overflow-hidden text-ellipsis bg-[var(--secondary-background)]">
+            {formatCurrency(results.loanAmount || 0)}
+          </div>
+        </div>
+        <div className="flex flex-col my-3">
+          <h3 className="text-lg font-bold mb-4">Monthly breakdown</h3>
+          <hr />
+        </div>
+        <div className="flex flex-col sm:flex-row mb-1 sm:bg-[var(--results-white-background)] rounded-lg">
+          <div className="w-full sm:w-[50%] text-md p-4 font-bold text-black bg-grey-med-dark rounded-lg sm:rounded-l-lg sm:rounded-r-none flex items-center">
+            Mortgage payment:
+          </div>
+          <div className="w-full sm:w-[50%] text-lg-title p-4 rounded-lg sm:rounded-r-lg font-bold overflow-hidden text-ellipsis flex items-center bg-[var(--secondary-background)]">
+            {formatCurrency(results.monthlyMortgage || 0)}
+          </div>
+        </div>
+        <div className="flex flex-col sm:flex-row mb-1 sm:bg-[var(--results-white-background)] rounded-lg">
+          <div className="w-full sm:w-[50%] text-md p-4 font-bold text-black bg-grey-med-dark rounded-lg sm:rounded-l-lg sm:rounded-r-none flex items-center">
+            Property taxes:
+          </div>
+          <div className="w-full sm:w-[50%] text-lg-title p-4 rounded-lg sm:rounded-r-lg font-bold overflow-hidden text-ellipsis flex items-center bg-[var(--secondary-background)]">
+            {formatCurrency(results.monthlyTax || 0)}
+          </div>
+        </div>
+        <div className="flex flex-col sm:flex-row mb-1 sm:bg-[var(--results-white-background)] rounded-lg">
+          <div className="w-full sm:w-[50%] text-md p-4 font-bold text-black bg-grey-med-dark rounded-lg sm:rounded-l-lg sm:rounded-r-none flex items-center">
+            Insurance:
+          </div>
+          <div className="w-full sm:w-[50%] text-lg-title p-4 rounded-lg sm:rounded-r-lg font-bold overflow-hidden text-ellipsis flex items-center bg-[var(--secondary-background)]">
+            {formatCurrency(results.monthlyInsurance || 0)}
+          </div>
+        </div>
+        <div className="flex flex-col sm:flex-row mb-1 sm:bg-[var(--results-white-background)] rounded-lg">
+          <div className="w-full sm:w-[50%] text-md p-4 font-bold text-black bg-grey-med-dark rounded-lg sm:rounded-l-lg sm:rounded-r-none flex items-center">
+            HOA:
+          </div>
+          <div className="w-full sm:w-[50%] text-lg-title p-4 rounded-lg sm:rounded-r-lg font-bold overflow-hidden text-ellipsis flex items-center bg-[var(--secondary-background)]">
+            {formatCurrency(results.hoaDues || 0)}
+          </div>
+        </div>
+        <div className="flex flex-col sm:flex-row mb-1 sm:bg-[var(--results-white-background)] rounded-lg">
+          <div className="w-full sm:w-[50%] text-md p-4 font-bold text-white bg-navy rounded-lg sm:rounded-l-lg sm:rounded-r-none flex items-center">
+            Total monthly housing cost:
+          </div>
+          <div className="w-full sm:w-[50%] text-lg-title p-4 rounded-lg sm:rounded-r-lg font-bold bg-lagunita-lighter text-black overflow-hidden text-ellipsis flex items-center">
+            {formatCurrency(results.totalMonthlyHousingCost || 0)}
+          </div>
+        </div>
+        <div className="py-5">
+          <p className="text-sm">{headline}</p>
+        </div>
+      </div>
+    </div>
+  );
 
   return (
     <div className="p-6 max-w-5xl mx-auto">
@@ -207,19 +442,9 @@ export default function MortgageCalculator() {
         <div className="mb-8">
           <h1 className="sr-only">Mortgage Calculator Suite</h1>
 
-          {/* Fix 6: role="alert" so screen readers announce the error */}
-          {hasValidationError && (
-            <div
-              role="alert"
-              className="mb-4 rounded-3xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-900"
-            >
-              {validationErrorMessage}
-            </div>
-          )}
-
           <Tabs
             value={mode}
-            onValueChange={(v) => { setMode(v); setShowRateError(false); }}
+            onValueChange={(value) => setMode(value as Mode)}
             className="w-full"
           >
             <TabsList className="grid w-full grid-rows-1 sm:grid-cols-2 p-0 gap-4">
@@ -242,7 +467,6 @@ export default function MortgageCalculator() {
                   {/* Monthly payment */}
                   <div className="pb-5">
                     <div className="flex items-center gap-2 mb-1">
-                      {/* Fix 1: htmlFor links label to input */}
                       <label
                         htmlFor="monthly-payment"
                         className="block text-sm font-semibold"
@@ -256,7 +480,6 @@ export default function MortgageCalculator() {
                       </InfoPopover>
                     </div>
                     <div className="relative">
-                      {/* Fix 2: aria-hidden on decorative symbols */}
                       <span
                         aria-hidden="true"
                         className="absolute text-[var(--color-symbols)] left-3 top-1/2 -translate-y-1/2 font-medium"
@@ -267,34 +490,34 @@ export default function MortgageCalculator() {
                         id="monthly-payment"
                         type="text"
                         inputMode="numeric"
-                        value={
-                          monthlyPayment
-                            ? Number(monthlyPayment).toLocaleString("en-US")
-                            : ""
-                        }
+                        value={monthlyPayment ? Number(monthlyPayment).toLocaleString("en-US") : ""}
                         onChange={(e) => {
                           const raw = e.target.value.replace(/,/g, "");
                           if (raw === "" || /^\d*\.?\d*$/.test(raw)) {
                             setMonthlyPayment(raw);
                           }
                         }}
-                        className="w-full pl-8 pr-4 py-3 border-2 border-gray-300 rounded-lg focus:border-blue-500 focus:ring-2 focus:ring-blue-200 outline-none transition [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+                        onBlur={() => setTouched((t) => ({ ...t, monthlyPayment: true }))}
+                        aria-describedby={v.paymentMsg ? "monthly-payment-error" : undefined}
+                        aria-invalid={!!v.paymentMsg}
+                        className={`w-full pl-8 pr-4 py-3 border-2 rounded-lg focus:border-blue-500 focus:ring-2 focus:ring-blue-200 outline-none transition [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none ${v.paymentMsg ? "border-[var(--color-inline-error)]" : "border-gray-300"}`}
                       />
                     </div>
-                    <p className="text-xs mt-1">
-                      This is the amount allocated to the loan payment
-                      (principal + interest). Taxes, insurance, and HOA are
-                      added separately below.
-                    </p>
+                    {v.paymentMsg ? (
+                      <FieldError id="monthly-payment-error">{v.paymentMsg}</FieldError>
+                    ) : (
+                      <p className="text-xs mt-1">
+                        This is the amount allocated to the loan payment
+                        (principal + interest). Taxes, insurance, and HOA are
+                        added separately below.
+                      </p>
+                    )}
                   </div>
 
                   {/* Down Payment */}
                   <div className="pb-5">
                     <div className="flex flex-row pb-2 justify-between items-center">
-                      <span className="block text-sm font-semibold">
-                        Down payment
-                      </span>
-                      {/* Fix 4: fieldset+legend for radio group */}
+                      <span className="block text-sm font-semibold">Down payment</span>
                       <fieldset className="border-0 p-0 m-0">
                         <legend className="sr-only">Down payment type</legend>
                         <div className="flex flex-row gap-4">
@@ -305,24 +528,15 @@ export default function MortgageCalculator() {
                               checked={downPaymentMode === "percentage"}
                               onChange={() => {
                                 setDownPaymentMode("percentage");
-                                if (
-                                  downPaymentAmount >= 0 &&
-                                  calculatedHomePrice > 0
-                                ) {
-                                  const percentValue =
-                                    (downPaymentAmount / calculatedHomePrice) *
-                                    100;
+                                if (downPaymentAmount >= 0 && calculatedHomePrice > 0) {
+                                  const percentValue = (downPaymentAmount / calculatedHomePrice) * 100;
                                   setDownPaymentPercent(percentValue);
-                                  setDownPaymentPercentInput(
-                                    percentValue.toFixed(2),
-                                  );
+                                  setDownPaymentPercentInput(percentValue.toFixed(2));
                                 }
                               }}
                               className="w-4 h-4 accent-lagunita cursor-pointer"
                             />
-                            <span
-                              className={`text-xs transition ${downPaymentMode === "percentage" ? "font-semibold" : ""}`}
-                            >
+                            <span className={`text-xs transition ${downPaymentMode === "percentage" ? "font-semibold" : ""}`}>
                               Percent
                             </span>
                           </label>
@@ -333,21 +547,13 @@ export default function MortgageCalculator() {
                               checked={downPaymentMode === "dollar"}
                               onChange={() => {
                                 setDownPaymentMode("dollar");
-                                const amountValue =
-                                  calculatedHomePrice *
-                                  (downPaymentPercent / 100);
+                                const amountValue = calculatedHomePrice * (downPaymentPercent / 100);
                                 setDownPaymentAmount(amountValue);
-                                setDownPaymentAmountInput(
-                                  calculatedHomePrice > 0
-                                    ? Math.round(amountValue).toString()
-                                    : "",
-                                );
+                                setDownPaymentAmountInput(calculatedHomePrice > 0 ? Math.round(amountValue).toString() : "");
                               }}
                               className="w-4 h-4 accent-lagunita cursor-pointer"
                             />
-                            <span
-                              className={`text-xs transition ${downPaymentMode === "dollar" ? "font-semibold" : ""}`}
-                            >
+                            <span className={`text-xs transition ${downPaymentMode === "dollar" ? "font-semibold" : ""}`}>
                               Dollars
                             </span>
                           </label>
@@ -372,24 +578,19 @@ export default function MortgageCalculator() {
                                 setDownPaymentAmountInput("0");
                                 return;
                               }
-                              const value = clampPercent(Number(raw));
+                              const value = Number(raw);
                               setDownPaymentPercent(value);
                               const price = calculatedHomePrice || 0;
-                              const computedAmount = (value / 100) * price;
+                              const computedAmount = (clampPercent(value) / 100) * price;
                               setDownPaymentAmount(computedAmount);
-                              setDownPaymentAmountInput(
-                                Math.round(computedAmount).toString(),
-                              );
+                              setDownPaymentAmountInput(Math.round(computedAmount).toString());
                             }}
                             aria-label="Down payment percentage"
-                            className="w-full pl-4 pr-16 py-3 border-2 border-gray-300 rounded-lg focus:border-blue-500 focus:ring-2 focus:ring-blue-200 outline-none transition [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+                            aria-describedby={v.dpMsg ? "down-payment-afford-error" : undefined}
+                            aria-invalid={!!v.dpMsg}
+                            className={`w-full pl-4 pr-16 py-3 border-2 rounded-lg focus:border-blue-500 focus:ring-2 focus:ring-blue-200 outline-none transition [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none ${v.dpMsg ? "border-[var(--color-inline-error)]" : "border-gray-300"}`}
                           />
-                          <span
-                            aria-hidden="true"
-                            className="absolute right-4 top-1/2 -translate-y-1/2 text-[var(--color-symbols)] pointer-events-none"
-                          >
-                            %
-                          </span>
+                          <span aria-hidden="true" className="absolute right-4 top-1/2 -translate-y-1/2 text-[var(--color-symbols)] pointer-events-none">%</span>
                         </div>
                       ) : (
                         <div className="relative">
@@ -397,13 +598,7 @@ export default function MortgageCalculator() {
                             id="down-payment-amount-afford"
                             type="text"
                             inputMode="numeric"
-                            value={
-                              downPaymentAmountInput
-                                ? Number(downPaymentAmountInput).toLocaleString(
-                                    "en-US",
-                                  )
-                                : ""
-                            }
+                            value={downPaymentAmountInput ? Number(downPaymentAmountInput).toLocaleString("en-US") : ""}
                             onChange={(e) => {
                               const raw = e.target.value.replace(/,/g, "");
                               if (raw === "" || /^\d*$/.test(raw)) {
@@ -418,115 +613,57 @@ export default function MortgageCalculator() {
                               }
                             }}
                             aria-label="Down payment amount in dollars"
-                            className="w-full pl-8 pr-16 py-3 border-2 border-gray-300 rounded-lg focus:border-blue-500 focus:ring-2 focus:ring-blue-200 outline-none transition"
+                            aria-describedby={v.dpMsg ? "down-payment-afford-error" : undefined}
+                            aria-invalid={!!v.dpMsg}
+                            className={`w-full pl-8 pr-16 py-3 border-2 rounded-lg focus:border-blue-500 focus:ring-2 focus:ring-blue-200 outline-none transition ${v.dpMsg ? "border-[var(--color-inline-error)]" : "border-gray-300"}`}
                           />
-                          <span
-                            aria-hidden="true"
-                            className="absolute left-4 top-1/2 -translate-y-1/2 text-gray-500 pointer-events-none"
-                          >
-                            $
-                          </span>
+                          <span aria-hidden="true" className="absolute left-4 top-1/2 -translate-y-1/2 text-gray-500 pointer-events-none">$</span>
                         </div>
                       )}
-                      <p className="text-xs mt-1">
-                        Enter 0 if no down payment is planned.
-                      </p>
+                      {v.dpMsg ? (
+                        <FieldError id="down-payment-afford-error">{v.dpMsg}</FieldError>
+                      ) : (
+                        <p className="text-xs mt-1">Enter 0 if no down payment is planned.</p>
+                      )}
                     </div>
                   </div>
 
                   {/* Interest Rate */}
                   <div className="pb-5">
-                    <label
-                      htmlFor="interest-rate-afford"
-                      className="block text-sm font-semibold"
-                    >
+                    <label htmlFor="interest-rate-afford" className="block text-sm font-semibold">
                       Interest rate
                     </label>
                     <div className="relative">
                       <input
                         id="interest-rate-afford"
                         type="number"
-                        placeholder=""
                         step="0.1"
                         min="0"
+                        max="20"
                         value={interestRate}
-                        onChange={(e) => {
-                          const raw = e.target.value;
-                          if (raw === "") {
-                            setInterestRate("");
-                            return;
-                          }
-                          setInterestRate(Math.max(0, Number(raw)).toString());
-                        }}
-                        onBlur={() => {
-                          if (interestRate === "" && monthlyPayment !== "") {
-                            setShowRateError(true);
-                          } else {
-                            setShowRateError(false);
-                          }
-                        }}
-                        aria-describedby={
-                          showRateError
-                            ? "interest-rate-afford-error"
-                            : undefined
-                        }
-                        aria-invalid={showRateError}
-                        className={`w-full pr-8 pl-4 py-3 border-2 rounded-lg focus:border-blue-500 focus:ring-2 focus:ring-blue-200 outline-none transition [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none ${showRateError ? "border-[var(--color-inline-error)] border-2" : ""}`}
+                        onChange={(e) => setInterestRate(e.target.value)}
+                        onBlur={() => setTouched((t) => ({ ...t, interestRate: true }))}
+                        aria-describedby={v.rateMsg ? "interest-rate-afford-error" : undefined}
+                        aria-invalid={!!v.rateMsg}
+                        className={`w-full pr-8 pl-4 py-3 border-2 rounded-lg focus:border-blue-500 focus:ring-2 focus:ring-blue-200 outline-none transition [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none ${v.rateMsg ? "border-[var(--color-inline-error)]" : "border-gray-300"}`}
                       />
-                      <span
-                        aria-hidden="true"
-                        className="absolute right-4 top-1/2 -translate-y-1/2 text-[var(--color-symbols)] pointer-events-none"
-                      >
-                        %
-                      </span>
+                      <span aria-hidden="true" className="absolute right-4 top-1/2 -translate-y-1/2 text-[var(--color-symbols)] pointer-events-none">%</span>
                     </div>
-                    {showRateError && (
-                      <p
-                        id="interest-rate-afford-error"
-                        role="alert"
-                        className="mt-1 text-sm font-semibold text-[var(--color-inline-error)]"
-                      >
-                        Please enter an interest rate.
-                      </p>
-                      )}
+                    {v.rateMsg && <FieldError id="interest-rate-afford-error">{v.rateMsg}</FieldError>}
                   </div>
 
-                  {/* Loan Term — Fix 4: fieldset+legend */}
+                  {/* Loan Term */}
                   <div className="pb-5">
                     <fieldset className="border-0 p-0 m-0">
-                      <legend className="block text-sm font-semibold mb-2">
-                        Loan term
-                      </legend>
+                      <legend className="block text-sm font-semibold mb-2">Loan term</legend>
                       <div className="flex flex-col sm:flex-row gap-2">
                         <label className="flex-1 cursor-pointer flex flex-row">
-                          <input
-                            type="radio"
-                            name="loanTermAfford"
-                            value="15"
-                            checked={loanTerm === 15}
-                            onChange={() => setLoanTerm(15)}
-                            className="mr-3 w-4 accent-lagunita"
-                          />
-                          <span
-                            className={`self-center ${loanTerm === 15 ? "font-semibold" : "font-normal"}`}
-                          >
-                            15 years
-                          </span>
+                          <input type="radio" name="loanTermAfford" value="15" checked={loanTerm === 15} onChange={() => setLoanTerm(15)} className="mr-3 w-4 accent-lagunita" />
+                          <span className={`self-center ${loanTerm === 15 ? "font-semibold" : "font-normal"}`}>15 years</span>
                         </label>
                         <label className="flex-1 cursor-pointer flex flex-row">
-                          <input
-                            type="radio"
-                            name="loanTermAfford"
-                            value="30"
-                            checked={loanTerm === 30}
-                            onChange={() => setLoanTerm(30)}
-                            className="mr-3 w-4 accent-lagunita"
-                          />
-                          <span
-                            className={`self-center ${loanTerm === 30 ? "font-semibold" : "font-normal"}`}
-                          >
-                            30 years
-                          </span>
+                          <input type="radio" name="loanTermAfford" value="30" checked={loanTerm === 30} onChange={() => setLoanTerm(30)} className="mr-3 w-4 accent-lagunita" />
+                          <span className={`self-center ${loanTerm === 30 ? "font-semibold" : "font-normal"}`}>30 years</span>
                         </label>
                       </div>
                     </fieldset>
@@ -534,21 +671,14 @@ export default function MortgageCalculator() {
 
                   {/* Optional Section */}
                   <div className="pt-4 border-t border-gray-200">
-                    {/* Fix 7: proper h2 heading */}
-                    <h2 className="text-lg font-semibold mb-4">
-                      Additional housing costs
-                    </h2>
+                    <h2 className="text-lg font-semibold mb-4">Additional housing costs</h2>
 
                     {/* Property Taxes */}
                     <div className="pb-5">
                       <div className="flex flex-row pb-2 justify-between items-center">
-                        <span className="block text-sm font-semibold">
-                          Property taxes (annual)
-                        </span>
+                        <span className="block text-sm font-semibold">Property taxes (annual)</span>
                         <fieldset className="border-0 p-0 m-0">
-                          <legend className="sr-only">
-                            Property tax input type
-                          </legend>
+                          <legend className="sr-only">Property tax input type</legend>
                           <div className="flex flex-row gap-4">
                             <label className="flex items-center gap-2 cursor-pointer">
                               <input
@@ -558,27 +688,15 @@ export default function MortgageCalculator() {
                                 checked={propertyTaxMode === "percentage"}
                                 onChange={() => {
                                   setPropertyTaxMode("percentage");
-                                  if (
-                                    propertyTaxAmount &&
-                                    propertyTaxAmount > 0 &&
-                                    calculatedHomePrice > 0
-                                  ) {
-                                    setPropertyTaxPercent(
-                                      (propertyTaxAmount /
-                                        calculatedHomePrice) *
-                                        100,
-                                    );
+                                  if (propertyTaxAmount > 0 && calculatedHomePrice > 0) {
+                                    setPropertyTaxPercent((propertyTaxAmount / calculatedHomePrice) * 100);
                                   } else {
                                     setPropertyTaxPercent(0);
                                   }
                                 }}
                                 className="w-4 h-4 accent-lagunita cursor-pointer"
                               />
-                              <span
-                                className={`text-xs transition ${propertyTaxMode === "percentage" ? "font-semibold" : ""}`}
-                              >
-                                Percent
-                              </span>
+                              <span className={`text-xs transition ${propertyTaxMode === "percentage" ? "font-semibold" : ""}`}>Percent</span>
                             </label>
                             <label className="flex items-center gap-2 cursor-pointer">
                               <input
@@ -588,18 +706,11 @@ export default function MortgageCalculator() {
                                 checked={propertyTaxMode === "dollar"}
                                 onChange={() => {
                                   setPropertyTaxMode("dollar");
-                                  setPropertyTaxAmount(
-                                    calculatedHomePrice *
-                                      (propertyTaxPercent / 100),
-                                  );
+                                  setPropertyTaxAmount(calculatedHomePrice * (propertyTaxPercent / 100));
                                 }}
                                 className="w-4 h-4 accent-lagunita cursor-pointer"
                               />
-                              <span
-                                className={`text-xs transition ${propertyTaxMode === "dollar" ? "font-semibold" : ""}`}
-                              >
-                                Dollars
-                              </span>
+                              <span className={`text-xs transition ${propertyTaxMode === "dollar" ? "font-semibold" : ""}`}>Dollars</span>
                             </label>
                           </div>
                         </fieldset>
@@ -612,25 +723,16 @@ export default function MortgageCalculator() {
                             step="0.01"
                             value={propertyTaxPercent || ""}
                             onChange={(e) => {
-                              const value = clampNonNegativeNumber(
-                                e.target.value === ""
-                                  ? 0
-                                  : Number(e.target.value),
-                              );
+                              const value = clampNonNegativeNumber(e.target.value === "" ? 0 : Number(e.target.value));
                               setPropertyTaxPercent(value);
-                              setPropertyTaxAmount(
-                                (value / 100) * (calculatedHomePrice || 0),
-                              );
+                              setPropertyTaxAmount((value / 100) * (calculatedHomePrice || 0));
                             }}
                             aria-label="Property tax percentage"
-                            className="w-full pl-4 pr-16 py-3 border-2 border-gray-300 rounded-lg focus:border-blue-500 focus:ring-2 focus:ring-blue-200 outline-none transition [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+                            aria-describedby={v.taxMsg ? "property-tax-afford-error" : undefined}
+                            aria-invalid={!!v.taxMsg}
+                            className={`w-full pl-4 pr-16 py-3 border-2 rounded-lg focus:border-blue-500 focus:ring-2 focus:ring-blue-200 outline-none transition [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none ${v.taxMsg ? "border-[var(--color-inline-error)]" : "border-gray-300"}`}
                           />
-                          <span
-                            aria-hidden="true"
-                            className="absolute right-4 top-1/2 -translate-y-1/2 text-[var(--color-symbols)] pointer-events-none"
-                          >
-                            %
-                          </span>
+                          <span aria-hidden="true" className="absolute right-4 top-1/2 -translate-y-1/2 text-[var(--color-symbols)] pointer-events-none">%</span>
                         </div>
                       ) : (
                         <div className="relative">
@@ -638,49 +740,33 @@ export default function MortgageCalculator() {
                             id="property-tax-amount-afford"
                             type="text"
                             inputMode="numeric"
-                            value={
-                              propertyTaxAmount
-                                ? Math.round(propertyTaxAmount).toLocaleString(
-                                    "en-US",
-                                  )
-                                : ""
-                            }
+                            value={propertyTaxAmount ? Math.round(propertyTaxAmount).toLocaleString("en-US") : ""}
                             onChange={(e) => {
                               const raw = e.target.value.replace(/,/g, "");
                               if (raw === "" || /^\d*$/.test(raw)) {
-                                const value =
-                                  raw === ""
-                                    ? 0
-                                    : clampNonNegativeNumber(Number(raw));
+                                const value = raw === "" ? 0 : clampNonNegativeNumber(Number(raw));
                                 setPropertyTaxAmount(value);
                                 const price = calculatedHomePrice || 0;
-                                if (price > 0)
-                                  setPropertyTaxPercent((value / price) * 100);
+                                if (price > 0) setPropertyTaxPercent((value / price) * 100);
                               }
                             }}
                             aria-label="Property tax annual dollar amount"
-                            className="w-full pl-8 pr-16 py-3 border-2 border-gray-300 rounded-lg focus:border-blue-500 focus:ring-2 focus:ring-blue-200 outline-none transition"
+                            aria-describedby={v.taxMsg ? "property-tax-afford-error" : undefined}
+                            aria-invalid={!!v.taxMsg}
+                            className={`w-full pl-8 pr-16 py-3 border-2 rounded-lg focus:border-blue-500 focus:ring-2 focus:ring-blue-200 outline-none transition ${v.taxMsg ? "border-[var(--color-inline-error)]" : "border-gray-300"}`}
                           />
-                          <span
-                            aria-hidden="true"
-                            className="absolute left-4 top-1/2 -translate-y-1/2 text-[var(--color-symbols)] pointer-events-none"
-                          >
-                            $
-                          </span>
+                          <span aria-hidden="true" className="absolute left-4 top-1/2 -translate-y-1/2 text-[var(--color-symbols)] pointer-events-none">$</span>
                         </div>
                       )}
+                      {v.taxMsg && <FieldError id="property-tax-afford-error">{v.taxMsg}</FieldError>}
                     </div>
 
                     {/* Homeowners Insurance */}
                     <div className="pb-5">
                       <div className="flex flex-row pb-2 justify-between items-center">
-                        <span className="block text-sm font-semibold">
-                          Homeowners insurance (annual)
-                        </span>
+                        <span className="block text-sm font-semibold">Homeowners insurance (annual)</span>
                         <fieldset className="border-0 p-0 m-0">
-                          <legend className="sr-only">
-                            Home insurance input type
-                          </legend>
+                          <legend className="sr-only">Home insurance input type</legend>
                           <div className="flex flex-row gap-4">
                             <label className="flex items-center gap-2 cursor-pointer">
                               <input
@@ -690,27 +776,15 @@ export default function MortgageCalculator() {
                                 checked={homeInsuranceMode === "percentage"}
                                 onChange={() => {
                                   setHomeInsuranceMode("percentage");
-                                  if (
-                                    homeInsuranceAmount &&
-                                    homeInsuranceAmount > 0 &&
-                                    calculatedHomePrice > 0
-                                  ) {
-                                    setHomeInsurancePercent(
-                                      (homeInsuranceAmount /
-                                        calculatedHomePrice) *
-                                        100,
-                                    );
+                                  if (homeInsuranceAmount > 0 && calculatedHomePrice > 0) {
+                                    setHomeInsurancePercent((homeInsuranceAmount / calculatedHomePrice) * 100);
                                   } else {
                                     setHomeInsurancePercent(0);
                                   }
                                 }}
                                 className="w-4 h-4 accent-lagunita cursor-pointer"
                               />
-                              <span
-                                className={`text-xs transition ${homeInsuranceMode === "percentage" ? "font-semibold" : ""}`}
-                              >
-                                Percent
-                              </span>
+                              <span className={`text-xs transition ${homeInsuranceMode === "percentage" ? "font-semibold" : ""}`}>Percent</span>
                             </label>
                             <label className="flex items-center gap-2 cursor-pointer">
                               <input
@@ -720,18 +794,11 @@ export default function MortgageCalculator() {
                                 checked={homeInsuranceMode === "dollar"}
                                 onChange={() => {
                                   setHomeInsuranceMode("dollar");
-                                  setHomeInsuranceAmount(
-                                    calculatedHomePrice *
-                                      (homeInsurancePercent / 100),
-                                  );
+                                  setHomeInsuranceAmount(calculatedHomePrice * (homeInsurancePercent / 100));
                                 }}
                                 className="w-4 h-4 accent-lagunita cursor-pointer"
                               />
-                              <span
-                                className={`text-xs transition ${homeInsuranceMode === "dollar" ? "font-semibold" : ""}`}
-                              >
-                                Dollars
-                              </span>
+                              <span className={`text-xs transition ${homeInsuranceMode === "dollar" ? "font-semibold" : ""}`}>Dollars</span>
                             </label>
                           </div>
                         </fieldset>
@@ -744,25 +811,16 @@ export default function MortgageCalculator() {
                             step="0.01"
                             value={homeInsurancePercent || ""}
                             onChange={(e) => {
-                              const value = clampNonNegativeNumber(
-                                e.target.value === ""
-                                  ? 0
-                                  : Number(e.target.value),
-                              );
+                              const value = clampNonNegativeNumber(e.target.value === "" ? 0 : Number(e.target.value));
                               setHomeInsurancePercent(value);
-                              setHomeInsuranceAmount(
-                                (value / 100) * (calculatedHomePrice || 0),
-                              );
+                              setHomeInsuranceAmount((value / 100) * (calculatedHomePrice || 0));
                             }}
                             aria-label="Home insurance percentage"
-                            className="w-full pl-4 pr-16 py-3 border-2 border-gray-300 rounded-lg focus:border-blue-500 focus:ring-2 focus:ring-blue-200 outline-none transition [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+                            aria-describedby={v.insMsg ? "home-insurance-afford-error" : undefined}
+                            aria-invalid={!!v.insMsg}
+                            className={`w-full pl-4 pr-16 py-3 border-2 rounded-lg focus:border-blue-500 focus:ring-2 focus:ring-blue-200 outline-none transition [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none ${v.insMsg ? "border-[var(--color-inline-error)]" : "border-gray-300"}`}
                           />
-                          <span
-                            aria-hidden="true"
-                            className="absolute right-4 top-1/2 -translate-y-1/2 text-[var(--color-symbols)] pointer-events-none"
-                          >
-                            %
-                          </span>
+                          <span aria-hidden="true" className="absolute right-4 top-1/2 -translate-y-1/2 text-[var(--color-symbols)] pointer-events-none">%</span>
                         </div>
                       ) : (
                         <div className="relative">
@@ -770,199 +828,72 @@ export default function MortgageCalculator() {
                             id="home-insurance-amount-afford"
                             type="text"
                             inputMode="numeric"
-                            value={
-                              homeInsuranceAmount
-                                ? Math.round(
-                                    homeInsuranceAmount,
-                                  ).toLocaleString("en-US")
-                                : ""
-                            }
+                            value={homeInsuranceAmount ? Math.round(homeInsuranceAmount).toLocaleString("en-US") : ""}
                             onChange={(e) => {
                               const raw = e.target.value.replace(/,/g, "");
                               if (raw === "" || /^\d*$/.test(raw)) {
-                                const value =
-                                  raw === ""
-                                    ? 0
-                                    : clampNonNegativeNumber(Number(raw));
+                                const value = raw === "" ? 0 : clampNonNegativeNumber(Number(raw));
                                 setHomeInsuranceAmount(value);
                                 const price = calculatedHomePrice || 0;
-                                if (price > 0)
-                                  setHomeInsurancePercent(
-                                    (value / price) * 100,
-                                  );
+                                if (price > 0) setHomeInsurancePercent((value / price) * 100);
                               }
                             }}
                             aria-label="Home insurance annual dollar amount"
-                            className="w-full pl-8 pr-16 py-3 border-2 border-gray-300 rounded-lg focus:border-blue-500 focus:ring-2 focus:ring-blue-200 outline-none transition"
+                            aria-describedby={v.insMsg ? "home-insurance-afford-error" : undefined}
+                            aria-invalid={!!v.insMsg}
+                            className={`w-full pl-8 pr-16 py-3 border-2 rounded-lg focus:border-blue-500 focus:ring-2 focus:ring-blue-200 outline-none transition ${v.insMsg ? "border-[var(--color-inline-error)]" : "border-gray-300"}`}
                           />
-                          <span
-                            aria-hidden="true"
-                            className="absolute left-4 top-1/2 -translate-y-1/2 text-[var(--color-symbols)] pointer-events-none"
-                          >
-                            $
-                          </span>
+                          <span aria-hidden="true" className="absolute left-4 top-1/2 -translate-y-1/2 text-[var(--color-symbols)] pointer-events-none">$</span>
                         </div>
                       )}
+                      {v.insMsg && <FieldError id="home-insurance-afford-error">{v.insMsg}</FieldError>}
                     </div>
 
                     {/* HOA Dues */}
                     <div className="pb-5">
-                      <label
-                        htmlFor="hoa-dues-afford"
-                        className="block text-sm font-semibold"
-                      >
-                        HOA dues (monthly)
-                      </label>
+                      <label htmlFor="hoa-dues-afford" className="block text-sm font-semibold">HOA dues (monthly)</label>
                       <div className="relative">
-                        <span
-                          aria-hidden="true"
-                          className="absolute left-3 top-1/2 -translate-y-1/2 text-[var(--color-symbols)] font-medium"
-                        >
-                          $
-                        </span>
+                        <span aria-hidden="true" className="absolute left-3 top-1/2 -translate-y-1/2 text-[var(--color-symbols)] font-medium">$</span>
                         <input
                           id="hoa-dues-afford"
                           type="text"
                           inputMode="numeric"
-                          value={
-                            hoaDues
-                              ? Number(hoaDues).toLocaleString("en-US")
-                              : ""
-                          }
+                          value={hoaDues ? Number(hoaDues).toLocaleString("en-US") : ""}
                           onChange={(e) => {
                             const raw = e.target.value.replace(/,/g, "");
-                            if (raw === "") {
-                              setHoaDues("");
-                              return;
-                            }
-                            const clamped = Math.min(
-                              Math.max(0, Number(raw)),
-                              100000,
-                            );
-                            setHoaDues(clamped.toString());
+                            if (raw === "" || /^\d*$/.test(raw)) setHoaDues(raw);
                           }}
-                          placeholder=""
-                          step="1"
-                          min="0"
-                          max="100000"
-                          className="w-full pl-8 pr-4 py-3 border-2 border-gray-300 rounded-lg focus:border-blue-500 focus:ring-2 focus:ring-blue-200 outline-none transition [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+                          aria-describedby={v.hoaMsg ? "hoa-dues-afford-error" : undefined}
+                          aria-invalid={!!v.hoaMsg}
+                          className={`w-full pl-8 pr-4 py-3 border-2 rounded-lg focus:border-blue-500 focus:ring-2 focus:ring-blue-200 outline-none transition [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none ${v.hoaMsg ? "border-[var(--color-inline-error)]" : "border-gray-300"}`}
                         />
                       </div>
+                      {v.hoaMsg && <FieldError id="hoa-dues-afford-error">{v.hoaMsg}</FieldError>}
                     </div>
                   </div>
                 </div>
 
-                {/* Right Column - Results — Fix 3: aria-live */}
+                {/* Right Column - Results */}
                 <div className="pl-0">
-                  <Card
-                    aria-live="polite"
-                    aria-atomic="true"
-                    className="bg-[var(--card-background)] rounded-3xl p-[32px]"
-                  >
+                  <Card aria-live="polite" aria-atomic="true" className="bg-[var(--card-background)] rounded-3xl p-[32px]">
                     {showAffordResults ? (
                       <>
                         <CardHeader className="pb-2">
-                          {/* Fix 7: explicit h2 */}
-                          <CardTitle className="text-md font-bold">
-                            Estimated home price
-                          </CardTitle>
+                          <CardTitle className="text-md font-bold">Estimated home price</CardTitle>
                         </CardHeader>
                         <CardContent className="">
                           <div className="mb-6">
-                            <p
-                              className={
-                                results.homePrice > 0
-                                  ? "text-3xl font-bold text-[var(--color-teal)]"
-                                  : "text-lg font-bold text-gray-500 italic"
-                              }
-                            >
-                              {results.homePrice > 0
-                                ? formatCurrency(Number(results.homePrice))
-                                : emptyResultsString}
+                            <p className="text-3xl font-bold text-[var(--color-teal)]">
+                              {formatCurrency(Number(results.homePrice))}
                             </p>
                           </div>
-                          <div className="rounded-lg">
-                            <div className="innerwrapper">
-                              <div className="flex flex-col sm:flex-row mb-1 sm:bg-[var(--results-white-background)] rounded-lg">
-                                <div className="w-full sm:w-[50%] text-md p-4 font-bold text-black rounded-lg sm:rounded-l-lg sm:rounded-r-none bg-grey-med-dark items-center">
-                                  Down payment:
-                                </div>
-                                <div className="w-full sm:w-[50%] text-lg-title p-4 self-center rounded-lg sm:rounded-r-lg font-bold text-[var(--foreground)] overflow-hidden text-ellipsis bg-[var(--secondary-background)]">
-                                  {formatCurrency(results.downPayment || 0)}
-                                </div>
-                              </div>
-                              <div className="flex flex-col sm:flex-row mb-1 sm:bg-[var(--results-white-background)] rounded-lg">
-                                <div className="w-full sm:w-[50%] text-md p-4 text-black font-bold rounded-lg sm:rounded-l-lg sm:rounded-r-none bg-grey-med-dark">
-                                  Loan amount:
-                                </div>
-                                <div className="w-full sm:w-[50%] text-lg-title p-4 self-center rounded-lg sm:rounded-r-lg text-palo-verde font-bold overflow-hidden text-ellipsis bg-[var(--secondary-background)]">
-                                  {formatCurrency(results.loanAmount || 0)}
-                                </div>
-                              </div>
-                              <div className="flex flex-col my-3">
-                                <h3 className="text-lg font-bold mb-4">
-                                  Monthly breakdown
-                                </h3>
-                                <hr />
-                              </div>
-                              <div className="flex flex-col sm:flex-row mb-1 sm:bg-[var(--results-white-background)] rounded-lg">
-                                <div className="w-full sm:w-[50%] text-md p-4 font-bold text-black bg-grey-med-dark rounded-lg sm:rounded-l-lg sm:rounded-r-none flex items-center">
-                                  Mortgage payment:
-                                </div>
-                                <div className="w-full sm:w-[50%] text-lg-title p-4 rounded-lg sm:rounded-r-lg font-bold overflow-hidden text-ellipsis flex items-center bg-[var(--secondary-background)]">
-                                  {formatCurrency(results.monthlyMortgage || 0)}
-                                </div>
-                              </div>
-                              <div className="flex flex-col sm:flex-row mb-1 sm:bg-[var(--results-white-background)] rounded-lg">
-                                <div className="w-full sm:w-[50%] text-md p-4 font-bold text-black bg-grey-med-dark rounded-lg sm:rounded-l-lg sm:rounded-r-none flex items-center">
-                                  Property taxes:
-                                </div>
-                                <div className="w-full sm:w-[50%] text-lg-title p-4 rounded-lg sm:rounded-r-lg font-bold overflow-hidden text-ellipsis flex items-center bg-[var(--secondary-background)]">
-                                  {formatCurrency(results.monthlyTax || 0)}
-                                </div>
-                              </div>
-                              <div className="flex flex-col sm:flex-row mb-1 sm:bg-[var(--results-white-background)] rounded-lg">
-                                <div className="w-full sm:w-[50%] text-md p-4 font-bold text-black bg-grey-med-dark rounded-lg sm:rounded-l-lg sm:rounded-r-none flex items-center">
-                                  Insurance:
-                                </div>
-                                <div className="w-full sm:w-[50%] text-lg-title p-4 rounded-lg sm:rounded-r-lg font-bold overflow-hidden text-ellipsis flex items-center bg-[var(--secondary-background)]">
-                                  {formatCurrency(
-                                    results.monthlyInsurance || 0,
-                                  )}
-                                </div>
-                              </div>
-                              <div className="flex flex-col sm:flex-row mb-1 sm:bg-[var(--results-white-background)] rounded-lg">
-                                <div className="w-full sm:w-[50%] text-md p-4 font-bold text-black bg-grey-med-dark rounded-lg sm:rounded-l-lg sm:rounded-r-none flex items-center">
-                                  HOA:
-                                </div>
-                                <div className="w-full sm:w-[50%] text-lg-title p-4 rounded-lg sm:rounded-r-lg font-bold overflow-hidden text-ellipsis flex items-center bg-[var(--secondary-background)]">
-                                  {formatCurrency(results.hoaDues || 0)}
-                                </div>
-                              </div>
-                              <div className="flex flex-col sm:flex-row mb-1 sm:bg-[var(--results-white-background)] rounded-lg">
-                                <div className="w-full sm:w-[50%] text-md p-4 font-bold text-white bg-navy rounded-lg sm:rounded-l-lg sm:rounded-r-none flex items-center">
-                                  Total monthly housing cost:
-                                </div>
-                                <div className="w-full sm:w-[50%] text-lg-title p-4 rounded-lg sm:rounded-r-lg font-bold bg-lagunita-lighter text-black overflow-hidden text-ellipsis flex items-center">
-                                  {formatCurrency(
-                                    results.totalMonthlyHousingCost || 0,
-                                  )}
-                                </div>
-                              </div>
-                              <div className="py-5">
-                                <p className="text-sm">
-                                  This estimate is based on the portion of your
-                                  monthly budget allocated to principal and
-                                  interest. Taxes, insurance, and HOA are shown
-                                  separately.
-                                </p>
-                              </div>
-                            </div>
-                          </div>
+                          <ResultsBody headline="This estimate is based on the portion of your monthly budget allocated to principal and interest. Taxes, insurance, and HOA are shown separately." />
                         </CardContent>
                       </>
+                    ) : affordCoral ? (
+                      <CoralCard message={limitReached ? limitString : fixFieldsString} />
                     ) : (
-                      <div className="min-h-[28rem]" />
+                      <EmptyPanel />
                     )}
                   </Card>
                 </div>
@@ -972,82 +903,53 @@ export default function MortgageCalculator() {
             {/* ── Tab 2: Payment ────────────────────────────────────────── */}
             <TabsContent value="payment">
               <p className="text-sm text-muted-foreground">
-                Estimate a monthly mortgage payment based on your target home
-                price.
+                Estimate a monthly mortgage payment based on your target home price.
               </p>
               <div className="grid md:grid-cols-2 py-8 gap-8">
                 <div className="pb-5">
                   {/* Home Price */}
                   <div className="pb-5">
-                    <label
-                      htmlFor="home-price"
-                      className="block text-sm font-semibold"
-                    >
-                      Home price
-                    </label>
+                    <label htmlFor="home-price" className="block text-sm font-semibold">Home price</label>
                     <div className="relative">
-                      <span
-                        aria-hidden="true"
-                        className="absolute left-4 top-1/2 -translate-y-1/2 text-[var(--color-symbols)] pointer-events-none"
-                      >
-                        $
-                      </span>
+                      <span aria-hidden="true" className="absolute left-4 top-1/2 -translate-y-1/2 text-[var(--color-symbols)] pointer-events-none">$</span>
                       <input
                         id="home-price"
                         type="text"
                         inputMode="numeric"
-                        placeholder=""
-                        value={
-                          homePrice
-                            ? Number(homePrice).toLocaleString("en-US")
-                            : ""
-                        }
+                        value={homePrice ? Number(homePrice).toLocaleString("en-US") : ""}
                         onChange={(e) => {
                           const raw = e.target.value.replace(/,/g, "");
                           if (raw === "" || /^\d*$/.test(raw)) {
                             setHomePrice(raw);
-                            const priceValue = Math.max(0, Number(raw));
+                            const priceValue = Number(raw) || 0;
                             if (downPaymentMode === "dollar") {
-                              const clampedDownPayment = clampDownPaymentAmount(
-                                downPaymentAmount,
-                                priceValue,
-                              );
-                              setDownPaymentAmount(clampedDownPayment);
-                              setDownPaymentAmountInput(
-                                Math.round(clampedDownPayment).toString(),
-                              );
-                              const percentValue =
-                                priceValue > 0
-                                  ? (clampedDownPayment / priceValue) * 100
-                                  : 0;
+                              const percentValue = priceValue > 0 ? (downPaymentAmount / priceValue) * 100 : 0;
                               setDownPaymentPercent(percentValue);
-                              setDownPaymentPercentInput(
-                                percentValue.toFixed(2),
-                              );
+                              setDownPaymentPercentInput(percentValue.toFixed(2));
                             } else {
-                              const computedAmount =
-                                (downPaymentPercent / 100) * priceValue;
+                              const computedAmount = (downPaymentPercent / 100) * priceValue;
                               setDownPaymentAmount(computedAmount);
-                              setDownPaymentAmountInput(
-                                Math.round(computedAmount).toString(),
-                              );
+                              setDownPaymentAmountInput(Math.round(computedAmount).toString());
                             }
                           }
                         }}
-                        className="w-full pl-8 pr-4 py-3 border-2 border-gray-300 rounded-lg focus:border-blue-500 focus:ring-2 focus:ring-blue-200 outline-none transition"
+                        onBlur={() => setTouched((t) => ({ ...t, homePrice: true }))}
+                        aria-describedby={v.priceMsg ? "home-price-error" : undefined}
+                        aria-invalid={!!v.priceMsg}
+                        className={`w-full pl-8 pr-4 py-3 border-2 rounded-lg focus:border-blue-500 focus:ring-2 focus:ring-blue-200 outline-none transition ${v.priceMsg ? "border-[var(--color-inline-error)]" : "border-gray-300"}`}
                       />
                     </div>
-                    <p className="text-xs mt-1">
-                      Enter the purchase price of the home.
-                    </p>
+                    {v.priceMsg ? (
+                      <FieldError id="home-price-error">{v.priceMsg}</FieldError>
+                    ) : (
+                      <p className="text-xs mt-1">Enter the purchase price of the home.</p>
+                    )}
                   </div>
 
                   {/* Down Payment */}
                   <div className="pb-5">
                     <div className="flex flex-row pb-2 justify-between items-center">
-                      <span className="block text-sm font-semibold">
-                        Down payment
-                      </span>
+                      <span className="block text-sm font-semibold">Down payment</span>
                       <fieldset className="border-0 p-0 m-0">
                         <legend className="sr-only">Down payment type</legend>
                         <div className="flex flex-row gap-4">
@@ -1058,26 +960,15 @@ export default function MortgageCalculator() {
                               checked={downPaymentMode === "percentage"}
                               onChange={() => {
                                 setDownPaymentMode("percentage");
-                                if (
-                                  downPaymentAmount >= 0 &&
-                                  Number(homePrice) > 0
-                                ) {
-                                  const percentValue =
-                                    (downPaymentAmount / Number(homePrice)) *
-                                    100;
+                                if (downPaymentAmount >= 0 && Number(homePrice) > 0) {
+                                  const percentValue = (downPaymentAmount / Number(homePrice)) * 100;
                                   setDownPaymentPercent(percentValue);
-                                  setDownPaymentPercentInput(
-                                    percentValue.toFixed(2),
-                                  );
+                                  setDownPaymentPercentInput(percentValue.toFixed(2));
                                 }
                               }}
                               className="w-4 h-4 accent-lagunita cursor-pointer"
                             />
-                            <span
-                              className={`text-xs transition ${downPaymentMode === "percentage" ? "font-semibold" : ""}`}
-                            >
-                              Percent
-                            </span>
+                            <span className={`text-xs transition ${downPaymentMode === "percentage" ? "font-semibold" : ""}`}>Percent</span>
                           </label>
                           <label className="flex items-center gap-2 cursor-pointer">
                             <input
@@ -1086,23 +977,13 @@ export default function MortgageCalculator() {
                               checked={downPaymentMode === "dollar"}
                               onChange={() => {
                                 setDownPaymentMode("dollar");
-                                const amountValue =
-                                  Number(homePrice) *
-                                  (downPaymentPercent / 100);
+                                const amountValue = Number(homePrice) * (downPaymentPercent / 100);
                                 setDownPaymentAmount(amountValue);
-                                setDownPaymentAmountInput(
-                                  Number(homePrice) > 0
-                                    ? Math.round(amountValue).toString()
-                                    : "",
-                                );
+                                setDownPaymentAmountInput(Number(homePrice) > 0 ? Math.round(amountValue).toString() : "");
                               }}
                               className="w-4 h-4 accent-lagunita cursor-pointer"
                             />
-                            <span
-                              className={`text-xs transition ${downPaymentMode === "dollar" ? "font-semibold" : ""}`}
-                            >
-                              Dollars
-                            </span>
+                            <span className={`text-xs transition ${downPaymentMode === "dollar" ? "font-semibold" : ""}`}>Dollars</span>
                           </label>
                         </div>
                       </fieldset>
@@ -1125,24 +1006,19 @@ export default function MortgageCalculator() {
                                 setDownPaymentAmountInput("0");
                                 return;
                               }
-                              const value = clampPercent(Number(raw));
+                              const value = Number(raw);
                               setDownPaymentPercent(value);
                               const price = Number(homePrice) || 0;
-                              const computedAmount = (value / 100) * price;
+                              const computedAmount = (clampPercent(value) / 100) * price;
                               setDownPaymentAmount(computedAmount);
-                              setDownPaymentAmountInput(
-                                Math.round(computedAmount).toString(),
-                              );
+                              setDownPaymentAmountInput(Math.round(computedAmount).toString());
                             }}
                             aria-label="Down payment percentage"
-                            className="w-full pl-4 pr-16 py-3 border-2 border-gray-300 rounded-lg focus:border-blue-500 focus:ring-2 focus:ring-blue-200 outline-none transition [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+                            aria-describedby={v.dpMsg ? "down-payment-payment-error" : undefined}
+                            aria-invalid={!!v.dpMsg}
+                            className={`w-full pl-4 pr-16 py-3 border-2 rounded-lg focus:border-blue-500 focus:ring-2 focus:ring-blue-200 outline-none transition [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none ${v.dpMsg ? "border-[var(--color-inline-error)]" : "border-gray-300"}`}
                           />
-                          <span
-                            aria-hidden="true"
-                            className="absolute right-4 top-1/2 -translate-y-1/2 text-[var(--color-symbols)] pointer-events-none"
-                          >
-                            %
-                          </span>
+                          <span aria-hidden="true" className="absolute right-4 top-1/2 -translate-y-1/2 text-[var(--color-symbols)] pointer-events-none">%</span>
                         </div>
                       ) : (
                         <div className="relative">
@@ -1150,13 +1026,7 @@ export default function MortgageCalculator() {
                             id="down-payment-amount-payment"
                             type="text"
                             inputMode="numeric"
-                            value={
-                              downPaymentAmountInput
-                                ? Number(downPaymentAmountInput).toLocaleString(
-                                    "en-US",
-                                  )
-                                : ""
-                            }
+                            value={downPaymentAmountInput ? Number(downPaymentAmountInput).toLocaleString("en-US") : ""}
                             onChange={(e) => {
                               const raw = e.target.value.replace(/,/g, "");
                               if (raw === "" || /^\d*$/.test(raw)) {
@@ -1167,121 +1037,65 @@ export default function MortgageCalculator() {
                                   setDownPaymentPercentInput("0");
                                   return;
                                 }
-                                const maxPrice = Number(homePrice) || 0;
-                                const clampedAmount = clampDownPaymentAmount(
-                                  Number(raw),
-                                  maxPrice,
-                                );
-                                setDownPaymentAmount(clampedAmount);
-                                const percentValue =
-                                  maxPrice > 0
-                                    ? (clampedAmount / maxPrice) * 100
-                                    : 0;
+                                // No clamp: an amount >= home price must surface as an error (#24).
+                                const amount = Number(raw);
+                                setDownPaymentAmount(amount);
+                                const price = Number(homePrice) || 0;
+                                const percentValue = price > 0 ? (amount / price) * 100 : 0;
                                 setDownPaymentPercent(percentValue);
-                                setDownPaymentPercentInput(
-                                  percentValue.toFixed(2),
-                                );
+                                setDownPaymentPercentInput(percentValue.toFixed(2));
                               }
                             }}
                             aria-label="Down payment amount in dollars"
-                            className="w-full pl-8 pr-16 py-3 border-2 border-gray-300 rounded-lg focus:border-blue-500 focus:ring-2 focus:ring-blue-200 outline-none transition"
+                            aria-describedby={v.dpMsg ? "down-payment-payment-error" : undefined}
+                            aria-invalid={!!v.dpMsg}
+                            className={`w-full pl-8 pr-16 py-3 border-2 rounded-lg focus:border-blue-500 focus:ring-2 focus:ring-blue-200 outline-none transition ${v.dpMsg ? "border-[var(--color-inline-error)]" : "border-gray-300"}`}
                           />
-                          <span
-                            aria-hidden="true"
-                            className="absolute left-4 top-1/2 -translate-y-1/2 text-[var(--color-symbols)] pointer-events-none"
-                          >
-                            $
-                          </span>
+                          <span aria-hidden="true" className="absolute left-4 top-1/2 -translate-y-1/2 text-[var(--color-symbols)] pointer-events-none">$</span>
                         </div>
                       )}
-                      <p className="text-xs mt-1">
-                        Enter 0 if no down payment is planned.
-                      </p>
+                      {v.dpMsg ? (
+                        <FieldError id="down-payment-payment-error">{v.dpMsg}</FieldError>
+                      ) : (
+                        <p className="text-xs mt-1">Enter 0 if no down payment is planned.</p>
+                      )}
                     </div>
                   </div>
 
                   {/* Interest Rate */}
                   <div className="pb-5">
-                    <label
-                      htmlFor="interest-rate-payment"
-                      className="block text-sm font-semibold"
-                    >
-                      Interest rate
-                    </label>
+                    <label htmlFor="interest-rate-payment" className="block text-sm font-semibold">Interest rate</label>
                     <div className="relative">
                       <input
                         id="interest-rate-payment"
                         type="number"
-                        placeholder=""
                         step="0.1"
                         min="0"
+                        max="20"
                         value={interestRate}
-                        onChange={(e) => {
-                          const raw = e.target.value;
-                          if (raw === '') { setInterestRate(''); return; }
-                          setInterestRate(Math.max(0, Number(raw)).toString());
-                        }}
-                        onBlur={() => {
-                          if (interestRate === '' && homePrice !== '') {
-                            setShowRateError(true);
-                          } else {
-                            setShowRateError(false);
-                          }
-                        }}
-                        aria-describedby={showRateError ? "interest-rate-payment-error" : undefined}
-                        aria-invalid={showRateError}
-                        className={`w-full pr-8 pl-4 py-3 border-2 rounded-lg focus:border-blue-500 focus:ring-2 focus:ring-blue-200 outline-none transition [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none ${showRateError ? "border-[var(--color-inline-error)] border-2" : ""}`}
+                        onChange={(e) => setInterestRate(e.target.value)}
+                        onBlur={() => setTouched((t) => ({ ...t, interestRate: true }))}
+                        aria-describedby={v.rateMsg ? "interest-rate-payment-error" : undefined}
+                        aria-invalid={!!v.rateMsg}
+                        className={`w-full pr-8 pl-4 py-3 border-2 rounded-lg focus:border-blue-500 focus:ring-2 focus:ring-blue-200 outline-none transition [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none ${v.rateMsg ? "border-[var(--color-inline-error)]" : "border-gray-300"}`}
                       />
-                      <span
-                        aria-hidden="true"
-                        className="absolute right-4 top-1/2 -translate-y-1/2 text-[var(--color-symbols)] pointer-events-none"
-                      >
-                        %
-                      </span>
+                      <span aria-hidden="true" className="absolute right-4 top-1/2 -translate-y-1/2 text-[var(--color-symbols)] pointer-events-none">%</span>
                     </div>
-                    {showRateError && (
-                      <p id="interest-rate-payment-error" role="alert" className="mt-1 text-sm font-semibold text-[var(--color-inline-error)]">
-                        Please enter an interest rate.
-                      </p>
-                    )}
+                    {v.rateMsg && <FieldError id="interest-rate-payment-error">{v.rateMsg}</FieldError>}
                   </div>
 
-                  {/* Loan Term — Fix 5: separate name from afford tab */}
+                  {/* Loan Term */}
                   <div className="pb-5">
                     <fieldset className="border-0 p-0 m-0">
-                      <legend className="block text-sm font-semibold mb-2">
-                        Loan term
-                      </legend>
+                      <legend className="block text-sm font-semibold mb-2">Loan term</legend>
                       <div className="flex flex-col sm:flex-row gap-2">
                         <label className="flex-1 cursor-pointer flex flex-row">
-                          <input
-                            type="radio"
-                            name="loanTermPayment"
-                            value="15"
-                            checked={loanTerm === 15}
-                            onChange={() => setLoanTerm(15)}
-                            className="mr-3 w-4 accent-lagunita"
-                          />
-                          <span
-                            className={`self-center ${loanTerm === 15 ? "font-semibold" : "font-normal"}`}
-                          >
-                            15 years
-                          </span>
+                          <input type="radio" name="loanTermPayment" value="15" checked={loanTerm === 15} onChange={() => setLoanTerm(15)} className="mr-3 w-4 accent-lagunita" />
+                          <span className={`self-center ${loanTerm === 15 ? "font-semibold" : "font-normal"}`}>15 years</span>
                         </label>
                         <label className="flex-1 cursor-pointer flex flex-row">
-                          <input
-                            type="radio"
-                            name="loanTermPayment"
-                            value="30"
-                            checked={loanTerm === 30}
-                            onChange={() => setLoanTerm(30)}
-                            className="mr-3 w-4 accent-lagunita"
-                          />
-                          <span
-                            className={`self-center ${loanTerm === 30 ? "font-semibold" : "font-normal"}`}
-                          >
-                            30 years
-                          </span>
+                          <input type="radio" name="loanTermPayment" value="30" checked={loanTerm === 30} onChange={() => setLoanTerm(30)} className="mr-3 w-4 accent-lagunita" />
+                          <span className={`self-center ${loanTerm === 30 ? "font-semibold" : "font-normal"}`}>30 years</span>
                         </label>
                       </div>
                     </fieldset>
@@ -1289,20 +1103,14 @@ export default function MortgageCalculator() {
 
                   {/* Optional Section */}
                   <div className="pt-4 border-t border-gray-200">
-                    <h2 className="text-lg font-semibold mb-4">
-                      Additional housing costs
-                    </h2>
+                    <h2 className="text-lg font-semibold mb-4">Additional housing costs</h2>
 
                     {/* Property Taxes */}
                     <div className="pb-5">
                       <div className="flex flex-row pb-2 justify-between items-center">
-                        <span className="block text-sm font-semibold">
-                          Property taxes (annual)
-                        </span>
+                        <span className="block text-sm font-semibold">Property taxes (annual)</span>
                         <fieldset className="border-0 p-0 m-0">
-                          <legend className="sr-only">
-                            Property tax input type
-                          </legend>
+                          <legend className="sr-only">Property tax input type</legend>
                           <div className="flex flex-row gap-4">
                             <label className="flex items-center gap-2 cursor-pointer">
                               <input
@@ -1311,15 +1119,8 @@ export default function MortgageCalculator() {
                                 checked={propertyTaxMode === "percentage"}
                                 onChange={() => {
                                   setPropertyTaxMode("percentage");
-                                  if (
-                                    propertyTaxAmount &&
-                                    propertyTaxAmount > 0 &&
-                                    Number(homePrice) > 0
-                                  ) {
-                                    setPropertyTaxPercent(
-                                      (propertyTaxAmount / Number(homePrice)) *
-                                        100,
-                                    );
+                                  if (propertyTaxAmount > 0 && Number(homePrice) > 0) {
+                                    setPropertyTaxPercent((propertyTaxAmount / Number(homePrice)) * 100);
                                   } else {
                                     setPropertyTaxPercent(0);
                                   }
@@ -1335,10 +1136,7 @@ export default function MortgageCalculator() {
                                 checked={propertyTaxMode === "dollar"}
                                 onChange={() => {
                                   setPropertyTaxMode("dollar");
-                                  setPropertyTaxAmount(
-                                    Number(homePrice) *
-                                      (propertyTaxPercent / 100),
-                                  );
+                                  setPropertyTaxAmount(Number(homePrice) * (propertyTaxPercent / 100));
                                 }}
                                 className="w-4 h-4 accent-lagunita cursor-pointer"
                               />
@@ -1353,27 +1151,19 @@ export default function MortgageCalculator() {
                             <input
                               id="property-tax-percent-payment"
                               type="number"
+                              step="0.01"
                               value={propertyTaxPercent || ""}
                               onChange={(e) => {
-                                const value = clampNonNegativeNumber(
-                                  e.target.value === ""
-                                    ? 0
-                                    : Number(e.target.value),
-                                );
+                                const value = clampNonNegativeNumber(e.target.value === "" ? 0 : Number(e.target.value));
                                 setPropertyTaxPercent(value);
-                                setPropertyTaxAmount(
-                                  (value / 100) * (Number(homePrice) || 0),
-                                );
+                                setPropertyTaxAmount((value / 100) * (Number(homePrice) || 0));
                               }}
                               aria-label="Property tax percentage"
-                              className="w-full pl-4 pr-16 py-3 border-2 border-gray-300 rounded-lg focus:border-blue-500 focus:ring-2 focus:ring-blue-200 outline-none transition [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+                              aria-describedby={v.taxMsg ? "property-tax-payment-error" : undefined}
+                              aria-invalid={!!v.taxMsg}
+                              className={`w-full pl-4 pr-16 py-3 border-2 rounded-lg focus:border-blue-500 focus:ring-2 focus:ring-blue-200 outline-none transition [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none ${v.taxMsg ? "border-[var(--color-inline-error)]" : "border-gray-300"}`}
                             />
-                            <span
-                              aria-hidden="true"
-                              className="absolute right-4 top-1/2 -translate-y-1/2 text-[var(--color-symbols)] pointer-events-none"
-                            >
-                              %
-                            </span>
+                            <span aria-hidden="true" className="absolute right-4 top-1/2 -translate-y-1/2 text-[var(--color-symbols)] pointer-events-none">%</span>
                           </>
                         ) : (
                           <>
@@ -1381,52 +1171,34 @@ export default function MortgageCalculator() {
                               id="property-tax-amount-payment"
                               type="text"
                               inputMode="numeric"
-                              value={
-                                propertyTaxAmount
-                                  ? Math.round(
-                                      propertyTaxAmount,
-                                    ).toLocaleString("en-US")
-                                  : ""
-                              }
+                              value={propertyTaxAmount ? Math.round(propertyTaxAmount).toLocaleString("en-US") : ""}
                               onChange={(e) => {
                                 const raw = e.target.value.replace(/,/g, "");
                                 if (raw === "" || /^\d*$/.test(raw)) {
-                                  const value =
-                                    raw === ""
-                                      ? 0
-                                      : clampNonNegativeNumber(Number(raw));
+                                  const value = raw === "" ? 0 : clampNonNegativeNumber(Number(raw));
                                   setPropertyTaxAmount(value);
                                   const price = Number(homePrice) || 0;
-                                  if (price > 0)
-                                    setPropertyTaxPercent(
-                                      (value / price) * 100,
-                                    );
+                                  if (price > 0) setPropertyTaxPercent((value / price) * 100);
                                 }
                               }}
                               aria-label="Property tax annual dollar amount"
-                              className="w-full pl-8 pr-16 py-3 border-2 border-gray-300 rounded-lg focus:border-blue-500 focus:ring-2 focus:ring-blue-200 outline-none transition"
+                              aria-describedby={v.taxMsg ? "property-tax-payment-error" : undefined}
+                              aria-invalid={!!v.taxMsg}
+                              className={`w-full pl-8 pr-16 py-3 border-2 rounded-lg focus:border-blue-500 focus:ring-2 focus:ring-blue-200 outline-none transition ${v.taxMsg ? "border-[var(--color-inline-error)]" : "border-gray-300"}`}
                             />
-                            <span
-                              aria-hidden="true"
-                              className="absolute left-4 top-1/2 -translate-y-1/2 text-[var(--color-symbols)] pointer-events-none"
-                            >
-                              $
-                            </span>
+                            <span aria-hidden="true" className="absolute left-4 top-1/2 -translate-y-1/2 text-[var(--color-symbols)] pointer-events-none">$</span>
                           </>
                         )}
                       </div>
+                      {v.taxMsg && <FieldError id="property-tax-payment-error">{v.taxMsg}</FieldError>}
                     </div>
 
                     {/* Homeowners Insurance */}
                     <div className="pb-5">
                       <div className="flex flex-row pb-2 justify-between items-center">
-                        <span className="block text-sm font-semibold">
-                          Homeowners insurance (annual)
-                        </span>
+                        <span className="block text-sm font-semibold">Homeowners insurance (annual)</span>
                         <fieldset className="border-0 p-0 m-0">
-                          <legend className="sr-only">
-                            Home insurance input type
-                          </legend>
+                          <legend className="sr-only">Home insurance input type</legend>
                           <div className="flex flex-row gap-4">
                             <label className="flex items-center gap-2 cursor-pointer">
                               <input
@@ -1435,16 +1207,8 @@ export default function MortgageCalculator() {
                                 checked={homeInsuranceMode === "percentage"}
                                 onChange={() => {
                                   setHomeInsuranceMode("percentage");
-                                  if (
-                                    homeInsuranceAmount &&
-                                    homeInsuranceAmount > 0 &&
-                                    Number(homePrice) > 0
-                                  ) {
-                                    setHomeInsurancePercent(
-                                      (homeInsuranceAmount /
-                                        Number(homePrice)) *
-                                        100,
-                                    );
+                                  if (homeInsuranceAmount > 0 && Number(homePrice) > 0) {
+                                    setHomeInsurancePercent((homeInsuranceAmount / Number(homePrice)) * 100);
                                   } else {
                                     setHomeInsurancePercent(0);
                                   }
@@ -1460,10 +1224,7 @@ export default function MortgageCalculator() {
                                 checked={homeInsuranceMode === "dollar"}
                                 onChange={() => {
                                   setHomeInsuranceMode("dollar");
-                                  setHomeInsuranceAmount(
-                                    Number(homePrice) *
-                                      (homeInsurancePercent / 100),
-                                  );
+                                  setHomeInsuranceAmount(Number(homePrice) * (homeInsurancePercent / 100));
                                 }}
                                 className="w-4 h-4 accent-lagunita cursor-pointer"
                               />
@@ -1478,27 +1239,19 @@ export default function MortgageCalculator() {
                             <input
                               id="home-insurance-percent-payment"
                               type="number"
+                              step="0.01"
                               value={homeInsurancePercent || ""}
                               onChange={(e) => {
-                                const value = clampNonNegativeNumber(
-                                  e.target.value === ""
-                                    ? 0
-                                    : Number(e.target.value),
-                                );
+                                const value = clampNonNegativeNumber(e.target.value === "" ? 0 : Number(e.target.value));
                                 setHomeInsurancePercent(value);
-                                setHomeInsuranceAmount(
-                                  (value / 100) * (Number(homePrice) || 0),
-                                );
+                                setHomeInsuranceAmount((value / 100) * (Number(homePrice) || 0));
                               }}
                               aria-label="Home insurance percentage"
-                              className="w-full pl-4 pr-16 py-3 border-2 border-gray-300 rounded-lg focus:border-blue-500 focus:ring-2 focus:ring-blue-200 outline-none transition [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+                              aria-describedby={v.insMsg ? "home-insurance-payment-error" : undefined}
+                              aria-invalid={!!v.insMsg}
+                              className={`w-full pl-4 pr-16 py-3 border-2 rounded-lg focus:border-blue-500 focus:ring-2 focus:ring-blue-200 outline-none transition [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none ${v.insMsg ? "border-[var(--color-inline-error)]" : "border-gray-300"}`}
                             />
-                            <span
-                              aria-hidden="true"
-                              className="absolute right-4 top-1/2 -translate-y-1/2 text-[var(--color-symbols)] pointer-events-none"
-                            >
-                              %
-                            </span>
+                            <span aria-hidden="true" className="absolute right-4 top-1/2 -translate-y-1/2 text-[var(--color-symbols)] pointer-events-none">%</span>
                           </>
                         ) : (
                           <>
@@ -1506,201 +1259,79 @@ export default function MortgageCalculator() {
                               id="home-insurance-amount-payment"
                               type="text"
                               inputMode="numeric"
-                              value={
-                                homeInsuranceAmount
-                                  ? Math.round(
-                                      homeInsuranceAmount,
-                                    ).toLocaleString("en-US")
-                                  : ""
-                              }
+                              value={homeInsuranceAmount ? Math.round(homeInsuranceAmount).toLocaleString("en-US") : ""}
                               onChange={(e) => {
                                 const raw = e.target.value.replace(/,/g, "");
                                 if (raw === "" || /^\d*$/.test(raw)) {
-                                  const value =
-                                    raw === ""
-                                      ? 0
-                                      : clampNonNegativeNumber(Number(raw));
+                                  const value = raw === "" ? 0 : clampNonNegativeNumber(Number(raw));
                                   setHomeInsuranceAmount(value);
                                   const price = Number(homePrice) || 0;
-                                  if (price > 0)
-                                    setHomeInsurancePercent(
-                                      (value / price) * 100,
-                                    );
+                                  if (price > 0) setHomeInsurancePercent((value / price) * 100);
                                 }
                               }}
                               aria-label="Home insurance annual dollar amount"
-                              className="w-full pl-8 pr-16 py-3 border-2 border-gray-300 rounded-lg focus:border-blue-500 focus:ring-2 focus:ring-blue-200 outline-none transition"
+                              aria-describedby={v.insMsg ? "home-insurance-payment-error" : undefined}
+                              aria-invalid={!!v.insMsg}
+                              className={`w-full pl-8 pr-16 py-3 border-2 rounded-lg focus:border-blue-500 focus:ring-2 focus:ring-blue-200 outline-none transition ${v.insMsg ? "border-[var(--color-inline-error)]" : "border-gray-300"}`}
                             />
-                            <span
-                              aria-hidden="true"
-                              className="absolute left-4 top-1/2 -translate-y-1/2 text-gray-500 pointer-events-none"
-                            >
-                              $
-                            </span>
+                            <span aria-hidden="true" className="absolute left-4 top-1/2 -translate-y-1/2 text-gray-500 pointer-events-none">$</span>
                           </>
                         )}
                       </div>
+                      {v.insMsg && <FieldError id="home-insurance-payment-error">{v.insMsg}</FieldError>}
                     </div>
 
                     {/* HOA Dues */}
                     <div className="pb-5">
-                      <label
-                        htmlFor="hoa-dues-payment"
-                        className="block text-sm font-semibold"
-                      >
-                        HOA dues (monthly)
-                      </label>
+                      <label htmlFor="hoa-dues-payment" className="block text-sm font-semibold">HOA dues (monthly)</label>
                       <div className="relative">
-                        <span
-                          aria-hidden="true"
-                          className="absolute text-gray-500 left-3 top-1/2 -translate-y-1/2 font-medium"
-                        >
-                          $
-                        </span>
+                        <span aria-hidden="true" className="absolute text-gray-500 left-3 top-1/2 -translate-y-1/2 font-medium">$</span>
                         <input
                           id="hoa-dues-payment"
                           type="text"
                           inputMode="numeric"
-                          value={
-                            hoaDues
-                              ? Number(hoaDues).toLocaleString("en-US")
-                              : ""
-                          }
+                          value={hoaDues ? Number(hoaDues).toLocaleString("en-US") : ""}
                           onChange={(e) => {
                             const raw = e.target.value.replace(/,/g, "");
-                            if (raw === "") {
-                              setHoaDues("");
-                              return;
-                            }
-                            setHoaDues(Math.max(0, Number(raw)).toString());
+                            if (raw === "" || /^\d*$/.test(raw)) setHoaDues(raw);
                           }}
-                          placeholder=""
-                          step="1"
-                          min="0"
-                          className="w-full pl-8 pr-4 py-3 border-2 border-gray-300 rounded-lg focus:border-blue-500 focus:ring-2 focus:ring-blue-200 outline-none transition [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+                          aria-describedby={v.hoaMsg ? "hoa-dues-payment-error" : undefined}
+                          aria-invalid={!!v.hoaMsg}
+                          className={`w-full pl-8 pr-4 py-3 border-2 rounded-lg focus:border-blue-500 focus:ring-2 focus:ring-blue-200 outline-none transition [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none ${v.hoaMsg ? "border-[var(--color-inline-error)]" : "border-gray-300"}`}
                         />
                       </div>
+                      {v.hoaMsg && <FieldError id="hoa-dues-payment-error">{v.hoaMsg}</FieldError>}
                     </div>
                   </div>
                 </div>
 
-                {/* Right Column - Results — Fix 3: aria-live */}
+                {/* Right Column - Results */}
                 <div className="pl-0">
-                  <Card
-                    aria-live="polite"
-                    aria-atomic="true"
-                    className="bg-[var(--card-background)] rounded-3xl p-[32px]"
-                  >
+                  <Card aria-live="polite" aria-atomic="true" className="bg-[var(--card-background)] rounded-3xl p-[32px]">
                     {showPaymentResults ? (
                       <>
                         <CardHeader className="pb-2">
-                          <CardTitle className="text-md font-bold">
-                            Estimated monthly mortgage payment
-                          </CardTitle>
+                          <CardTitle className="text-md font-bold">Estimated monthly mortgage payment</CardTitle>
                         </CardHeader>
                         <CardContent className="">
                           <div className="mb-6">
-                            <p
-                              className={
-                                results.homePrice > 0
-                                  ? "text-3xl font-bold text-[var(--color-teal)]"
-                                  : "text-lg font-bold text-gray-500 italic"
-                              }
-                            >
-                              {results.homePrice > 0
-                                ? formatCurrency(
-                                    Number(results.monthlyMortgage),
-                                  )
-                                : emptyResultsString}
+                            <p className="text-3xl font-bold text-[var(--color-teal)]">
+                              {formatCurrency(Number(results.monthlyMortgage))}
                             </p>
                           </div>
-                          <div className="rounded-lg">
-                            <div className="innerwrapper">
-                              <div className="flex flex-col sm:flex-row mb-1 sm:bg-[var(--results-white-background)] rounded-lg">
-                                <div className="w-full sm:w-[50%] text-md p-4 font-bold text-black rounded-lg sm:rounded-l-lg sm:rounded-r-none bg-grey-med-dark items-center">
-                                  Down payment:
-                                </div>
-                                <div className="w-full sm:w-[50%] text-lg-title p-4 self-center rounded-lg sm:rounded-r-lg font-bold text-[var(--foreground)] overflow-hidden text-ellipsis bg-[var(--secondary-background)]">
-                                  {formatCurrency(results.downPayment || 0)}
-                                </div>
-                              </div>
-                              <div className="flex flex-col sm:flex-row mb-1 sm:bg-[var(--results-white-background)] rounded-lg">
-                                <div className="w-full sm:w-[50%] text-md p-4 text-black font-bold rounded-lg sm:rounded-l-lg sm:rounded-r-none bg-grey-med-dark">
-                                  Loan amount:
-                                </div>
-                                <div className="w-full sm:w-[50%] text-lg-title p-4 self-center rounded-lg sm:rounded-r-lg text-palo-verde font-bold overflow-hidden text-ellipsis bg-[var(--secondary-background)]">
-                                  {formatCurrency(results.loanAmount)}
-                                </div>
-                              </div>
-                              <div className="flex flex-col my-3">
-                                <h3 className="text-lg font-bold mb-4">
-                                  Monthly breakdown
-                                </h3>
-                                <hr />
-                              </div>
-                              <div className="flex flex-col sm:flex-row mb-1 sm:bg-[var(--results-white-background)] rounded-lg">
-                                <div className="w-full sm:w-[50%] text-md p-4 font-bold text-black bg-grey-med-dark rounded-lg sm:rounded-l-lg sm:rounded-r-none flex items-center">
-                                  Mortgage payment:
-                                </div>
-                                <div className="w-full sm:w-[50%] text-lg-title p-4 rounded-lg sm:rounded-r-lg font-bold overflow-hidden text-ellipsis flex items-center bg-[var(--secondary-background)]">
-                                  {formatCurrency(results.monthlyMortgage)}
-                                </div>
-                              </div>
-                              <div className="flex flex-col sm:flex-row mb-1 sm:bg-[var(--results-white-background)] rounded-lg">
-                                <div className="w-full sm:w-[50%] text-md p-4 font-bold text-black bg-grey-med-dark rounded-lg sm:rounded-l-lg sm:rounded-r-none flex items-center">
-                                  Property taxes:
-                                </div>
-                                <div className="w-full sm:w-[50%] text-lg-title p-4 rounded-lg sm:rounded-r-lg font-bold overflow-hidden text-ellipsis flex items-center bg-[var(--secondary-background)]">
-                                  {formatCurrency(results.monthlyTax)}
-                                </div>
-                              </div>
-                              <div className="flex flex-col sm:flex-row mb-1 sm:bg-[var(--results-white-background)] rounded-lg">
-                                <div className="w-full sm:w-[50%] text-md p-4 font-bold text-black bg-grey-med-dark rounded-lg sm:rounded-l-lg sm:rounded-r-none flex items-center">
-                                  Insurance:
-                                </div>
-                                <div className="w-full sm:w-[50%] text-lg-title p-4 rounded-lg sm:rounded-r-lg font-bold overflow-hidden text-ellipsis flex items-center bg-[var(--secondary-background)]">
-                                  {formatCurrency(results.monthlyInsurance)}
-                                </div>
-                              </div>
-                              <div className="flex flex-col sm:flex-row mb-1 sm:bg-[var(--results-white-background)] rounded-lg">
-                                <div className="w-full sm:w-[50%] text-md p-4 font-bold text-black bg-grey-med-dark rounded-lg sm:rounded-l-lg sm:rounded-r-none flex items-center">
-                                  HOA:
-                                </div>
-                                <div className="w-full sm:w-[50%] text-lg-title p-4 rounded-lg sm:rounded-r-lg font-bold overflow-hidden text-ellipsis flex items-center bg-[var(--secondary-background)]">
-                                  {formatCurrency(results.hoaDues)}
-                                </div>
-                              </div>
-                              <div className="flex flex-col sm:flex-row mb-1 sm:bg-[var(--results-white-background)] rounded-lg">
-                                <div className="w-full sm:w-[50%] text-md p-4 font-bold text-white bg-navy rounded-lg sm:rounded-l-lg sm:rounded-r-none flex items-center">
-                                  Total monthly housing cost:
-                                </div>
-                                <div className="w-full sm:w-[50%] text-lg-title p-4 rounded-lg sm:rounded-r-lg font-bold bg-lagunita-lighter text-black overflow-hidden text-ellipsis flex items-center">
-                                  {formatCurrency(
-                                    results.totalMonthlyHousingCost,
-                                  )}
-                                </div>
-                              </div>
-                              <div className="py-5">
-                                <p className="text-sm">
-                                  This estimate shows your monthly mortgage
-                                  payment based on the loan amount, interest
-                                  rate, and term. Taxes, insurance, and HOA are
-                                  shown separately.
-                                </p>
-                              </div>
-                            </div>
-                          </div>
+                          <ResultsBody headline="This estimate shows your monthly mortgage payment based on the loan amount, interest rate, and term. Taxes, insurance, and HOA are shown separately." />
                         </CardContent>
                       </>
+                    ) : paymentCoral ? (
+                      <CoralCard message={fixFieldsString} />
                     ) : (
-                      <div className="min-h-[28rem]" />
+                      <EmptyPanel />
                     )}
                   </Card>
                 </div>
               </div>
             </TabsContent>
 
-            {/* Fix 8: type="button" to prevent accidental form submit */}
             <div className="flex">
               <button
                 type="button"


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
**Shared fields**

1. Interest rate: empty error (touched-gated per Rachel's note) and 0 to 20 inclusive range error. Also stopped silently clamping negatives so the range message can actually fire.
2. Down payment %: 0 to 99.9 inclusive range error.
3. Property tax % and insurance %: 0 to 10 inclusive range errors.
4. Property tax $ and insurance $: relative 10%-of-home-price cap errors (uses calculatedHomePrice on Tab 1, homePriceon Tab 2).
5. HOA dues: 0 to 20,000 inclusive. Removed the old silent clamp (Tab 1 was clamping to 100,000, Tab 2 unbounded) so out-of-range now blocks with a message.

**Tab 1**

1. Row 15 monthly payment empty error; Row 16 hard cap $1 to $1,000,000 (0 and negatives rejected).
2. Row 18 dollar down payment absolute ceiling 0 to 1,000,000,000.
3. Row 19 output backstop: if the estimate runs away (non-finite or past a display ceiling) it shows the "payment too high" message instead of a garbage number.

**Tab 2**

1. Row 20 home price empty error; Row 22 range $1 to $1,000,000,000 inclusive.
2. Row 23 negative down payment message; Row 24 dollar down payment >= home price now blocks with an error. I removed the clampDownPaymentAmount calls that were silently capping it, since that clamp made Row 24 impossible to trigger.

**Cross-tab**

1. Note 3: killed the page-level red banner and moved everything to inline role="alert" messages next to each field, with aria-invalid and aria-describedby wired up and the border turning red on error.
2. Note 4: no more silent resets. Every blocked field carries a visible message.
3. Governing rule (result OR warning, never both): results panel now shows results only when clean, a warning message on a genuine bad value, or a blank "enter values" placeholder for untouched/empty-required. No stale numbers.