### PR TITLE
TVM: Fix to the interest rate calculator

### DIFF
--- a/app/interactives/time-value-money-calculator/page.tsx
+++ b/app/interactives/time-value-money-calculator/page.tsx
@@ -323,7 +323,13 @@ export default function Page() {
             break
           }
           // Newton-Raphson solve
-          let guess = 0.1 / compFreq
+          // NOTE: `guess` represents the rate per PAYMENT period, since it is
+          // applied directly against `n` (a count of payment periods) below.
+          // The seed must therefore scale with pmtFreq, not compFreq. When
+          // paymentFrequencyMode is "same", pmtFreq === compFreq, so this is
+          // a no-op change for that case; it only matters (and fixes
+          // divergence/NaN results) when the two frequencies differ.
+          let guess = 0.1 / pmtFreq
           let calculatedRate: number | null = null
           for (let i = 0; i < 100; i++) {
             const currentTiming = paymentTiming === "beginning" ? (1 + guess) : 1
@@ -351,6 +357,12 @@ export default function Page() {
               // M3
               throw new Error("No interest rate produces these values. Check that your cash flows include both a negative and a positive amount.")
             guess = guess - eq / deriv
+            // Guard rail: keep guess above -1 so (1 + guess) never goes
+            // non-positive. A negative base raised to the fractional
+            // exponent used during annualization (pmtFreq / compFreq)
+            // returns NaN, which otherwise surfaces as a false
+            // "Invalid result" error even when a valid rate exists.
+            if (guess <= -1) guess = -0.999999
             if (i === 99)
               // M3
               throw new Error("No interest rate produces these values. Check that your cash flows include both a negative and a positive amount.")


### PR DESCRIPTION
# READY FOR REVIEW
This fix was found by client's test case: 
Present value: $1,000
Payment per period: -$50
Future value: $0 
Number of periods: 60
Compounding frequency: weekly
Payments occur: different 
Payment frequency: quarterly 

---> our calculator outputs "Invalid result. Please check your inputs" 

Claude's explaination.
## Fix TVM RATE solver: incorrect Newton-Raphson seed for mismatched payment/compounding frequencies

**Problem**

The RATE solver returned "Invalid result. Please check your inputs." for valid inputs whenever `paymentFrequencyMode` was "different" and the two frequencies were far apart (e.g. weekly compounding with quarterly payments). Confirmed with PV=$1,000, PMT=-$50, FV=$0, n=60 quarters, compounding weekly, payments quarterly. Expected output: 18.32%.

**Root cause**

The Newton-Raphson loop seeds its initial guess with `0.1 / compFreq`. But `guess` represents the rate per payment period, since it's applied directly to `n` (a count of payment periods). When `compFreq` and `pmtFreq` diverge significantly, this seed lands far from the true root, causing the solver to diverge. In this case it landed on a spurious negative root where `1 + guess < 0`, and the annualization step raises that negative base to a fractional exponent (`pmtFreq / compFreq`), producing `NaN`. That `NaN` then trips the generic invalid-result check.

**Fix**

- Changed the seed to `0.1 / pmtFreq`, which matches what `guess` actually represents. No behavior change when `paymentFrequencyMode` is "same," since `pmtFreq === compFreq` in that case.
- Added a guard rail clamping `guess` to `-0.999999` if it ever drops to or below -1 during iteration, to prevent the same NaN failure mode from resurfacing under other extreme inputs.

**Verification**

- Reported case now returns 18.32%, matching an independent reference calculator.
- Re-ran same-frequency RATE cases (annual/annual, monthly/monthly) to confirm no regression in the common path.