### PR TITLE
Error appearing when page just loads.

### DIFF
--- a/app/interactives/present-value-calculator-v2/page.tsx
+++ b/app/interactives/present-value-calculator-v2/page.tsx
@@ -109,6 +109,7 @@ export default function PresentValueCalculator() {
   // Whether each tab has a blocking error (or empty required field) that should suppress results.
   const singleHasError = singleAnyFieldEmpty || !!futureValueError || !!interestRateError || !!timePeriodError
   const seriesHasError = seriesAnyFieldEmpty || !!paymentAmountError || !!finalAmountError || !!paymentInterestRateError || !!numberOfPaymentsError
+  const seriesHasActualError = !!paymentAmountError || !!finalAmountError || !!paymentInterestRateError || !!numberOfPaymentsError
 
   // Debounced inputs for calculations — updates after 300ms pause in typing
   // to avoid recalculating on every keystroke.
@@ -1004,7 +1005,7 @@ export default function PresentValueCalculator() {
                       ? "—"
                       : formatCurrency(paymentCalculations.presentValue)}
                   </p>
-                  {seriesHasError && (
+                  {seriesHasActualError && (
                     <p className="text-sm text-muted-foreground mb-3">
                       Fix the fields on the left to see results.
                     </p>

--- a/app/interactives/present-value-calculator-v2/page.tsx
+++ b/app/interactives/present-value-calculator-v2/page.tsx
@@ -109,7 +109,7 @@ export default function PresentValueCalculator() {
   // Whether each tab has a blocking error (or empty required field) that should suppress results.
   const singleHasError = singleAnyFieldEmpty || !!futureValueError || !!interestRateError || !!timePeriodError
   const seriesHasError = seriesAnyFieldEmpty || !!paymentAmountError || !!finalAmountError || !!paymentInterestRateError || !!numberOfPaymentsError
-  const seriesHasActualError = !!paymentAmountError || !!finalAmountError || !!paymentInterestRateError || !!numberOfPaymentsError
+  const seriesHasValidationError = !!paymentAmountError || !!finalAmountError || !!paymentInterestRateError || !!numberOfPaymentsError
 
   // Debounced inputs for calculations — updates after 300ms pause in typing
   // to avoid recalculating on every keystroke.
@@ -1005,7 +1005,7 @@ export default function PresentValueCalculator() {
                       ? "—"
                       : formatCurrency(paymentCalculations.presentValue)}
                   </p>
-                  {seriesHasActualError && (
+                  {seriesHasValidationError && (
                     <p className="text-sm text-muted-foreground mb-3">
                       Fix the fields on the left to see results.
                     </p>


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
#Problem

When you first open the calculator to the payment series tab, in the results window we have a line that says "Fix the fields on the left to see results". This is our error messaging and should not appear when the calculator is in a non-error state (I have attached a screenshot below). 

