### PR TITLE
Blocker and High priority fixes

### DIFF
--- a/app/interactives/interest-calculator/page.tsx
+++ b/app/interactives/interest-calculator/page.tsx
@@ -116,7 +116,6 @@ export default function InterestRateVisual() {
   const [periodsRaw, setPeriodsRaw] = useState("");
   const [periodsError, setPeriodsError] = useState("");
   const [periodsWarning, setPeriodsWarning] = useState("");
-  const [periodsInfo, setPeriodsInfo] = useState("");
 
   // Compounding
   const [compounding, setCompounding] =
@@ -161,8 +160,7 @@ export default function InterestRateVisual() {
     const rate = (parseFloat(debounced.rate) || 0) / 100;
     const periodsPerYear = frequencyMap[debounced.compounding].periods;
     const periodicRate = rate / periodsPerYear;
-    // Round periods to nearest whole number per spec
-    const periods = Math.round(parseFloat(debounced.periods) || 0);
+    const periods = parseFloat(debounced.periods) || 0;
 
     const calculatedTotal = amount * Math.pow(1 + periodicRate, periods);
     const calculatedInterest = calculatedTotal - amount;
@@ -192,7 +190,6 @@ export default function InterestRateVisual() {
     setPeriodsRaw("");
     setPeriodsError("");
     setPeriodsWarning("");
-    setPeriodsInfo("");
     setCompounding("annually");
     setDebounced({
       amount: "",
@@ -285,7 +282,6 @@ export default function InterestRateVisual() {
       setPeriodsRaw("");
       setPeriodsError("");
       setPeriodsWarning("");
-      setPeriodsInfo("");
       return;
     }
     const val = parseFloat(raw);
@@ -293,17 +289,11 @@ export default function InterestRateVisual() {
     if (val < 0 || val > maxPeriods) {
       setPeriodsError(buildPeriodsRangeError(compounding, maxPeriods));
       setPeriodsWarning("");
-      setPeriodsInfo("");
     } else {
       setPeriodsError("");
       setPeriodsWarning(
         val === 0
           ? "0 periods means no time passes. Final amount will equal the initial amount."
-          : "",
-      );
-      setPeriodsInfo(
-        val > 0 && !Number.isInteger(val)
-          ? "Rounded to the nearest whole period for calculation."
           : "",
       );
     }
@@ -513,12 +503,10 @@ export default function InterestRateVisual() {
                       ? "text-[var(--color-inline-error)]"
                       : periodsWarning
                         ? "text-[var(--color-inline-warning)]"
-                        : periodsInfo
-                          ? "text-[var(--foreground)]"
-                          : "sr-only"
+                        : "sr-only"
                   }`}
                 >
-                  {periodsError || periodsWarning || periodsInfo || ""}
+                  {periodsError || periodsWarning || ""}
                 </p>
               </div>
 
@@ -575,13 +563,6 @@ export default function InterestRateVisual() {
                 {resultTooLarge && (
                   <p className="font-bold m-2 text-[var(--color-inline-error)]">
                     Try a lower rate or fewer periods.
-                  </p>
-                )}
-
-                {/* Second helper: borrowing context, shown under the results */}
-                {mode === "borrowing" && !hasError && (
-                  <p className="font-bold m-2 text-[var(--foreground)]">
-                    This shows how the balance grows if left unpaid.
                   </p>
                 )}
 
@@ -644,7 +625,7 @@ export default function InterestRateVisual() {
                 <p className="text-[var(--foreground)] mb-2 text-md">
                   {mode === "saving"
                     ? "You are essentially a lender, and you get interest from those using your money."
-                    : "You are paying interest for the privilege of using someone else's money."}
+                    : "You are paying interest for the privilege of using someone else's money. This shows how the balance grows if left unpaid."}
                 </p>
               </div>
             </div>


### PR DESCRIPTION
Summary

Moves the "balance grows if left unpaid" line into the "When you borrow" explanation where it belongs, and switches the calculation to use the fractional periods value the user enters rather than a rounded whole number. Also removes the stray "Rounded to the nearest whole period" info message that was added to the errors doc by mistake.

Changes

- Appended "This shows how the balance grows if left unpaid." to the borrowing explanation copy so it renders as constant context, not a result-dependent line.
- Removed the borrowing helper block from the results panel. It was gated on `!hasError`, which made it appear above the results as soon as a valid calculation ran.
- Removed rounding in the calculation `useMemo`. `Math.pow` now receives the fractional periods directly, so 2.5 periods computes as 2.5, not 3.
- Removed the `periodsInfo` state and its "Rounded to the nearest whole period for calculation" message entirely (state declaration, reset handler, both change-handler branches, and the message paragraph fallback).

Testing

- $1 / 8% / 2.5 periods / annually now returns a final amount of $1.21 as expected.
- Verified the borrowing line no longer appears above the results in error or valid states, and shows only in the "When you borrow" section.
- Confirmed zero-period warning, range errors, and whole-number results are unchanged.