### PR TITLE
Fix misleading error message on the Interest Rate tab when no meaningful rate exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Releases are identified by deploy date.
 
 ## [Unreleased]
 
+### [2026-07-15]
+
+- TVM interest-rate tab now reports that no meaningful rate could be calculated, instead of a misleading cash-flow-signs error, when the only root falls below the -100% floor (#___).
+
 ## [2026-07-10]
 
 First tracked production release. Promotes the accumulated calculator work from

--- a/app/interactives/time-value-money-calculator/page.tsx
+++ b/app/interactives/time-value-money-calculator/page.tsx
@@ -53,6 +53,12 @@ const CONSTRAINTS = {
 // Ceiling above which a solved output is "Too large to display"
 const OUTPUT_OVERFLOW_CEILING = 1e15
 
+// Cash-flow signs are valid (M1 handles all-same-sign) but no economically
+// meaningful rate exists: the only mathematical root sits below the -100%
+// display floor, so the scan finds no bracket in the sensible range.
+const MSG_NO_MEANINGFUL_RATE =
+  "No interest rate could be calculated for these inputs. Try adjusting your values, or double-check the cash flow amounts and timing."
+
 interface FieldError {
   field: string
   message: string
@@ -399,8 +405,9 @@ export default function Page() {
           }
 
           if (bracketLo === null)
-            // M3
-            throw new Error("No interest rate produces these values. Check that your cash flows include both a negative and a positive amount.")
+            // Signs are already known to be mixed, so this is the
+            // "root exists only at a nonsensical rate" case, not a sign problem.
+            throw new Error(MSG_NO_MEANINGFUL_RATE)
 
           let solvedG = (bracketLo + bracketHi) / 2
           if (bracketLo !== bracketHi) {
@@ -459,7 +466,7 @@ export default function Page() {
       // The high side is intentionally uncapped. -100% exactly is allowed: it
       // is the legitimate total-loss result when fv = 0.
       if (solveFor === "RATE" && calculatedValue < -100)
-        throw new Error("No interest rate produces these values. Check that your cash flows include both a negative and a positive amount.")
+        throw new Error(MSG_NO_MEANINGFUL_RATE)
 
       // M5: output overflow ceiling — never render scientific notation
       if (


### PR DESCRIPTION

When solving for RATE, some inputs have valid cash-flow signs but no economically meaningful rate, because the only mathematical root sits below the -100% display floor and outside the solver's scan range. In that situation the code fell through to the generic message about cash-flow signs, which was wrong since the signs were never the problem. Reported by Rachel for PV $0, PMT -$50, FV $400, N 60, daily compounding.

The change adds a MSG_NO_MEANINGFUL_RATE constant and points the two branches that mean "no meaningful rate" at it: the bracketLo === null case (no sign change found in range) and the output-floor guard that rejects a solved rate below -100%. The M1 all-same-sign guard is untouched, so genuine sign problems still get the sign-specific message. The third copy of the old string, in the pmt === 0 && ratio <= 0 branch, is left as is since that path is a real sign problem and is effectively unreachable behind M1.

No behavior change for valid rates. If a real root exists in range, bracketLo is non-null and the new branch never fires, and the floor guard only triggers below -100%, which is never displayable. High positive rates such as the 1,707% daily case are unaffected and remain uncapped on the high side.
Verified with the spec in page.rate.test.ts: Rachel's case now returns the new message, genuine all-same-sign inputs still return the sign message, the exact -100% total-loss result still displays, and the weekly, daily, and ordinary-loan rates solve to their expected values.

Request:
As noted in email: Another note for the interest rate tab for the Time Value of Money calculator. This one is definitely the trickiest, I think. 

Right now I have entered: 
Present value: $0
Payment per period: -$50
Future value: $400
Number of periods: 60 
Compounding frequency: daily 
Our calculator returns a warning: "No interest rate produces these values. Check that your cash flows include both a negative and a positive amount" 

For this situation, the cash flows have the correct signs, so our error messaging is incorrect. 

I think what is happening is that the interest rate that would solve this equation is nonsensical or not economically meaningful so the calculator is rejecting it and throughing out our typical warning. 

Can we include logic that when the cash flow signs are correct but the interest rate doesn't make sense we show the warning  ""No interest rate could be calculated for these inputs. Try adjusting your values, or double-check the cash flow amounts and timing."

I will add this feedback to the spreadsheet, I don't think it needs to be addressed today, but is a high priority for post push. 
