### PR TITLE
Claude skills files

### DIFF
--- a/.claude/skills/calculator-qa/SKILL.md
+++ b/.claude/skills/calculator-qa/SKILL.md
@@ -1,0 +1,141 @@
+---
+name: calculator-qa
+description: >-
+  A manual QA checklist for verifying a calculator in this repo before calling a
+  change done. There is no automated test suite, so verification is by hand.
+  Covers correctness, boundary values, currency-input handling, the repo's
+  validation rules (invalid input stays visible, error vs. warning states,
+  required-field language, result suppression), the Reset contract, dark mode,
+  keyboard/accessibility, and basePath/iframe behavior. Use after editing or
+  adding a calculator, before merging or deploying. Do NOT use as a substitute
+  for deriving the math (that is rigorous-mathematician) or for root-causing a
+  specific bug (that is run-observe-propose-verify).
+---
+
+# Calculator QA checklist
+
+This repo has **no test suite**. Verification is manual: run `yarn dev` and
+exercise the calculator in the browser. This skill is the coverage list to run
+before calling a calculator change done. It complements, not replaces, the
+other skills: `rigorous-mathematician` proves the math is correct; `calculator-qa`
+confirms the *whole calculator* behaves across inputs, states, and environments.
+
+Run against the specific `app/interactives/<name>/page.tsx` you changed. Each
+calculator owns its own math and validation, so results here do **not** transfer
+to sibling calculators or `-v2` variants. QA each file you touched.
+
+The behaviors below are the repo-wide rules. Section references like "(§1)"
+point to `docs/calculator-global-rules.md`, which has the exact tokens, hex
+values, and code patterns for each one. Check the behavior here; read the doc
+for the specifics.
+
+## Preconditions
+
+- [ ] `yarn lint` passes (eslint, runs against `app/` only).
+- [ ] `yarn build:local` compiles. This is also what surfaces TypeScript errors,
+      since `yarn lint` is eslint only with no separate typecheck.
+- [ ] `yarn dev` and open `/interactives/<name>/`.
+
+## 1. Correctness (happy path)
+
+- [ ] A known input set produces the expected output; confirm against an
+      independent calculation (invoke `rigorous-mathematician` if unsure).
+- [ ] Every "solve for" / mode / tab produces sensible results.
+- [ ] Each compounding/payment frequency gives the right period count
+      (daily 365, weekly 52, bi-weekly 26, monthly 12, quarterly 4,
+      semi-annual 2, annual 1). A single wrong entry corrupts one frequency
+      only, so check more than the default.
+
+## 2. Boundary & edge values
+
+- [ ] **Zero interest rate** — the code special-cases it with `=== 0`, not
+      `<= 0`; no divide-by-zero or `log(1)`; result is the linear case
+      (e.g. principal / payment). (§10)
+- [ ] **Very high rate** and **very large principal** — no overflow garbage;
+      output above `1e15` renders as "Too large to display", never scientific
+      notation, if the file has that concept. (§9)
+- [ ] **Non-amortizing case** (payment ≤ periodic interest) — caught with a
+      clear message, not `NaN`/`Infinity` leaking to the UI.
+- [ ] **Single-period payoff** and other extremes at the constraint edges
+      (`CONSTRAINTS` min/max).
+- [ ] **Empty / partial / non-numeric input** (`""`, `-`, `.`, letters) — no
+      crash; sensible empty or error state.
+
+## 3. Currency & number input
+
+- [ ] Comma grouping displays correctly and is stripped before computing.
+- [ ] Decimal entry, leading `.`, and negative values (where allowed) behave on
+      change and on blur; a bare leading `.` gets a `0` prepended on blur. (§2)
+- [ ] Leading zeros are stripped on numeric fields (`007` becomes `7`) while
+      `0.8` and `.8` still work. (§2)
+- [ ] Dollar inputs show a permanent `$` on the left; rate inputs show a
+      permanent `%` on the right; both stay readable in dark mode. (§3)
+- [ ] Output uses `Intl.NumberFormat` currency formatting; non-finite values are
+      guarded (show `—`, not `NaN`). (§9)
+
+## 4. Validation: error & warning states
+
+- [ ] **Invalid input stays visible.** Typing an out-of-range or bad value keeps
+      the value in the field with an error beside it; the field never clears out
+      from under the user. This is the most important validation rule in the
+      repo. A field that blanks on invalid input is a bug. (§1)
+- [ ] Out-of-range inputs surface the correct `FieldError` message on the right
+      field.
+- [ ] Required-field error messages start with "Please enter" (e.g. "Please
+      enter an interest rate."), not a bare "Enter". (§6)
+- [ ] Calc-level errors (e.g. no meaningful rate) show the intended message.
+- [ ] Clearing a bad input clears its error.
+- [ ] **Empty required field suppresses the result.** When a required field is
+      blank, the result panel shows `—` rather than computing with an implicit
+      zero. Optional fields are excluded from that guard. (§7)
+- [ ] **Warnings work as advisory states.** Technically valid but unusual values
+      (0% rate, rate above 50%) show an amber warning and still calculate; they
+      do not block the result. (§5)
+- [ ] **Error wins over warning.** When a field could show both, the error takes
+      precedence; the ternary checks error first. (§5)
+- [ ] **Warning border matches warning text.** Every field showing amber warning
+      text also has the matching amber border. Amber text with no amber outline
+      (or the reverse) is a bug. (§5)
+
+## 5. Reset
+
+- [ ] The calculator has a Reset button (`Button` with `variant="lagunita"`,
+      `size="sm"`). (§13)
+- [ ] Reset clears **all** of: field values, error strings, warning strings,
+      touched state, and results (back to `—`). Verify each category, not just
+      the visible inputs; a leftover error or stale result is the usual Reset
+      bug. (§13)
+
+## 6. Dark mode & styling
+
+- [ ] Toggle dark/light — every color has a proper counterpart; no invisible or
+      low-contrast text.
+- [ ] Named Stanford tokens render correctly in both themes; no raw hardcoded
+      colors that break in dark mode.
+- [ ] Inline error and warning colors resolve correctly in both themes
+      (`var(--color-inline-error)`, `var(--color-inline-warning)`). (§4, §5)
+
+## 7. Accessibility
+
+- [ ] Every input has an associated `<Label htmlFor>`; there is an `sr-only`
+      `<h1>`.
+- [ ] Results region is `aria-live="polite"` and announces on change.
+- [ ] Help tooltips use the shared `InfoPopover`; the title is present for
+      screen readers via `sr-only` and the visible content is the description
+      only. (§14)
+- [ ] Full keyboard operation: tab order, selects reachable/operable, focus
+      visible.
+
+## 8. Embed / environment
+
+- [ ] No hardcoded absolute asset paths (basePath is environment-driven —
+      empty in prod, `/ifdm_learning_apps_staging` in staging).
+- [ ] Layout works at iframe-embed widths (narrow/responsive), since these are
+      embedded in Mighty Networks.
+
+## Report
+
+State exactly what you exercised: which inputs, frequencies, and states, and the
+pass/fail of each area. Call out anything you did **not** test (e.g. "did not
+verify on a mobile viewport"). A green compile is not a pass; behavior in the
+browser is.

--- a/.claude/skills/new-calculator/SKILL.md
+++ b/.claude/skills/new-calculator/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: new-calculator
+description: >-
+  Scaffold a new financial calculator in this repo following the established
+  self-contained pattern (typed constants, a CONSTRAINTS object, FieldError[]
+  validation, all inputs held as string in useState, currency formatting,
+  InfoPopover help, dark-mode tokens, aria). Use when the user asks to add,
+  create, or scaffold a new calculator/interactive/tool. Do NOT use for editing
+  an existing calculator's logic or for non-calculator pages.
+---
+
+# Scaffold a new calculator
+
+Every calculator in this repo is **one route = one file = one self-contained
+`"use client"` component** at `app/interactives/<name>/page.tsx`. Calculators do
+**not** share calculation logic — each owns its own state, math, validation, and
+constant tables. The home page (`app/page.tsx`) auto-discovers any directory
+with a `page.*` file, so no manual registration is needed.
+
+The canonical reference for the pattern is
+`app/interactives/time-value-money-calculator/page.tsx`. Read it before
+scaffolding and mirror its structure — do not invent a new shape.
+
+## Before writing
+
+1. Confirm the calculator name and its route slug (kebab-case, e.g.
+   `auto-loan-calculator`). Check no existing directory (or `-v2` variant)
+   already covers it.
+2. Confirm the inputs, the output(s), and the financial formula(s). If the math
+   is nontrivial, derive and cross-check it first — invoke `rigorous-mathematician`.
+3. Decide the constraints (min/max per field) and the validation rules.
+4. Full field-level conventions (error/warning tokens, "Please enter" language,
+currency formatting, sign helper) live in `docs/calculator-global-rules.md`.
+
+## The pattern to follow
+
+Create `app/interactives/<slug>/page.tsx` as a single `"use client"` component.
+Mirror the TVM reference for each of these:
+
+- **Header:** `"use client"`, then imports from `@/app/ui/components/*`,
+  `ThemeToggle` from `@/app/lib/theme-toggle`, and `InfoPopover` from
+  `@/app/ui/components/popover`.
+- **Typed constants at the top of the file:** option tables (e.g.
+  `FREQUENCY_OPTIONS` with `value`/`label`/`perYear`), a `CONSTRAINTS` object
+  with per-field `{ min, max }`, and any fixed message strings. Type them
+  explicitly.
+- **State:** hold **every input as a `string`** in `useState` (not `number`) —
+  this is deliberate for currency/partial-entry handling. Keep result,
+  overflow, and `fieldErrors: FieldError[]` in state.
+- **Input handling:** reuse the reference's `formatWithCommas` /
+  `handleInputChange` / `handleInputBlur` approach for currency inputs; strip
+  commas before `Number(...)`.
+- **Validation:** produce a `FieldError[]` (`{ field, message }`) and surface a
+  calc-level error string; validate against `CONSTRAINTS` and the edge cases
+  the math requires (zero rate, non-amortizing payment, etc.).
+- **Math:** own, self-contained functions in this file. Never divide the annual
+  rate by one periods-per-year and count periods with another. Special-case
+  `rate = 0`. Never round mid-calculation — round for display only.
+- **Formatting:** `Intl.NumberFormat("en-US", { style: "currency", currency:
+  "USD", ... })`; guard non-finite values.
+- **UI:** shadcn primitives (`Card`, `Input`, `Label`, `Select`, `Tabs`),
+  `cn()` from `@/app/lib/utils` for class composition, `InfoPopover` for each
+  field's help text, a `ThemeToggle`.
+- **Accessibility:** `<h1 className="sr-only">`, `<Label htmlFor>` on every
+  input, `aria-live="polite"` on the results region, `aria-describedby` for
+  selects. See the debt-payoff and TVM files.
+
+## Styling
+
+- Tailwind v4 with the Stanford named tokens (`lagunita`, `berry`, `navy`,
+  `--color-teal`, etc. in `app/ui/globals.css`). Prefer named tokens over raw
+  hex/rgba.
+- **Every color needs a dark-mode counterpart** (dark mode is class-based).
+- Never hardcode absolute asset paths — `basePath` is environment-driven
+  (empty in prod, `/ifdm_learning_apps_staging` in staging). Hardcoding breaks
+  one environment.
+
+## After scaffolding
+
+1. `yarn lint` and `yarn build:local` to confirm it compiles.
+2. `yarn dev`, open `/interactives/<slug>/`, and exercise it — there is no test
+   suite, so run the `calculator-qa` checklist (boundary values, dark mode,
+   keyboard/aria) before calling it done.
+3. Confirm it appears on the auto-discovered home index.

--- a/.claude/skills/rigorous-mathematician/SKILL.md
+++ b/.claude/skills/rigorous-mathematician/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: rigorous-mathematician
+description: >-
+  Adopt the mindset of an exceptionally rigorous mathematician who specializes
+  in accounting and finance: derive every financial formula from first
+  principles, cross-check results by an independent method, and reason
+  carefully about compounding, amortization, day-count/period conventions,
+  rounding, and sign conventions. Use when writing, reviewing, auditing, or
+  debugging the financial math in this repo's calculators (interest solvers,
+  amortization, present/future value, mortgages, debt payoff, currency
+  handling) or when the correctness of a number is in question. Do NOT use for
+  layout, styling, copy, or non-numerical UI work.
+---
+
+# The rigorous mathematician
+
+You are an exceptionally bright mathematician whose specialty is accounting and
+quantitative finance. You treat every reported number as a claim that must be
+provable. You are calm, precise, and allergic to hand-waving: you would rather
+say "I need to check that" than assert a formula from memory.
+
+This persona exists because the financial math in this repo is its most
+sensitive surface — the changelog shows repeated fixes to interest-rate
+solvers and edge cases (zero rate, high rate, cross-compounding frequency,
+currency input). A wrong formula here silently misleads a real learner about
+their money. Rigor is the job, not a flourish.
+
+## Operating principles
+
+1. **Derive, don't recall.** Write the governing equation from first principles
+   before trusting any closed form. For a level-payment loan, start from the
+   balance recurrence `B_{k+1} = B_k(1 + i) − P` and show how the payment or
+   period count falls out — don't just paste the annuity formula and hope the
+   algebra matches the code.
+
+2. **State conventions explicitly.** Before computing, pin down:
+   - **Periodic rate** `i = annualRate / periodsPerYear` — and confirm the code
+     divides by the *same* `periodsPerYear` it uses for the period count.
+   - **Compounding vs. payment frequency** — in these calculators they are
+     defined to be equal; verify that assumption still holds in the file.
+   - **Day-count / periods per year** — daily 365, weekly 52, bi-weekly 26,
+     monthly 12, quarterly 4, semi-annual 2, annual 1. A single wrong entry
+     here corrupts one frequency while leaving the others correct.
+   - **Sign convention** — cash out vs. cash in; which side principal, interest,
+     and payment sit on.
+   - **Rounding** — round only for display, never mid-calculation; know whether
+     a cent-level discrepancy is expected accumulation or a real bug.
+
+3. **Cross-check by a second method.** A closed-form result must agree with an
+   independent computation before you trust it. Preferred check: run the
+   amortization schedule period by period (`balance = balance*(1+i) − payment`)
+   and confirm it lands at ~0 at the stated payoff, and that the summed interest
+   matches the closed-form total. If the two disagree, the closed form or its
+   inputs are wrong — find out which; do not average them.
+
+4. **Interrogate the boundaries.** Every formula gets tested at its edges:
+   - **Zero rate** (`i = 0`): annuity formulas divide by zero or take `log(1)`;
+     confirm the code special-cases it (payoff time should be `principal /
+     payment`).
+   - **Payment ≤ periodic interest**: the debt never amortizes — the log
+     argument goes non-positive. Confirm this is caught, not returned as `NaN`.
+   - **Very high rate**, **very large principal**, **empty/`NaN` input**,
+     **payment that pays off in a single period**.
+
+5. **Localize, don't generalize.** Each `app/interactives/<name>/page.tsx` owns
+   its own math; a correct derivation for one calculator is not evidence about
+   another (including its `-v2` variant). Re-derive per file.
+
+6. **Show the work.** Every conclusion comes with the numbers: the inputs, the
+   intermediate periodic rate and period count, the closed-form result, and the
+   independent check that agrees with it. "It looks right" is not a finding.
+
+## Method
+
+1. Restate the quantity being computed and its exact inputs (with units and
+   frequency).
+2. Derive the governing equation from first principles; note every convention.
+3. Compute the closed-form result, showing intermediates.
+4. Independently verify — schedule iteration or an alternate formula — and
+   confirm agreement.
+5. Probe the boundary cases relevant to the change.
+6. Report: the result, the derivation, the cross-check, and any discrepancy
+   (with its magnitude and cause). If something is off, name the `file:line`.
+
+## Reference formulas (derive before using; listed only to anchor notation)
+
+Let `i` = periodic rate, `n` = number of periods, `PV` = principal, `P` =
+level payment.
+
+- Payment for a target term: `P = PV · i · (1+i)^n / ((1+i)^n − 1)`;
+  at `i = 0`, `P = PV / n`.
+- Periods to pay off a balance: `n = −ln(1 − PV·i / P) / ln(1 + i)`,
+  valid only when `P > PV·i`; at `i = 0`, `n = PV / P`.
+- Total interest: `total interest = P·n − PV`.
+- Balance recurrence (the ground truth for all of the above):
+  `B_{k+1} = B_k·(1 + i) − P`, `B_0 = PV`.
+
+Treat these as claims to be re-derived and cross-checked, not as authority.

--- a/.claude/skills/run-observe-propose-verify/SKILL.md
+++ b/.claude/skills/run-observe-propose-verify/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: run-observe-propose-verify
+description: >-
+  A disciplined loop for diagnosing bugs and validating changes: Run the code,
+  Observe the actual behavior, Propose a minimal fix rooted in evidence, then
+  Verify the fix by re-running and comparing against a known-good baseline. Use
+  when debugging unexpected behavior, changing financial math or validation
+  logic, or before calling any nontrivial change "done" — especially in this
+  repo, which has no automated test suite and relies on manual verification. Do
+  NOT use for feature requests, refactors, or style/copy changes with no
+  reported malfunction.
+---
+
+# Run, Observe, Propose, Verify (ROPV)
+
+A four-phase loop for changing code with confidence. The rule is simple: **never
+propose a fix from a theory alone, and never call a change done without
+re-observing it.** Evidence bookends every change.
+
+This repo has no test suite (see `CLAUDE.md`) and its financial math is a
+sensitive surface with a history of edge-case regressions. That makes the
+observe/verify halves non-optional here, not ceremony.
+
+## When to use
+
+- A calculator produces wrong or surprising numbers.
+- You're editing financial math, a solver, validation rules, or currency/input
+  handling.
+- You've made any nontrivial change and are about to say it works.
+- You're reviewing someone else's change and want to confirm the claimed effect.
+
+Skip it for pure copy/styling tweaks with no runtime behavior to observe.
+
+## The loop
+
+### 1. Run
+Get the code executing so you can see real behavior, not imagined behavior.
+
+- `yarn dev` and open the affected calculator in the browser, OR
+- `yarn build:local` to confirm it compiles, and `yarn lint`.
+- Reproduce the exact scenario in question: the specific inputs, frequency,
+  edge value (zero rate, very high rate, cross-compounding frequency, empty
+  field).
+
+Write down the inputs you used. A repro you can't restate is not a repro.
+
+If you **cannot** reproduce the symptom, say so explicitly and ask the user for
+more detail (browser, console output, screenshot, exact inputs) rather than
+guessing. Do not propose a fix for a bug you haven't seen.
+
+### 2. Observe
+Record what actually happens, precisely — before forming any theory.
+
+- Capture the actual output (the number, the date, the error).
+- Capture what you *expected* and where that expectation comes from (a
+  hand-calculation, another calculator, a known-good commit).
+- Note the delta. "Bi-weekly total interest is ~8% high" is an observation;
+  "the divisor is wrong" is already a guess — keep them separate.
+- Localize: does it affect one frequency or all? One tab or both? That narrows
+  cause to a shared helper vs. per-file logic. In these calculators, each
+  `app/interactives/<name>/page.tsx` owns its own math — a bug in one usually
+  does **not** exist in the others; confirm per file.
+
+### 3. Propose
+Only now form a fix, and make it the smallest change that the observation
+justifies.
+
+- State one specific, falsifiable root-cause hypothesis, tied to the observed
+  delta — something a re-run can prove wrong, not a vague "probably rounding."
+- Prefer a one-line/one-value fix over a rewrite. If the fix is large, your
+  diagnosis is probably incomplete — go back to Observe.
+- Predict, out loud, what the corrected output should be *before* you run it.
+- Check whether the same root cause appears in sibling calculators; fix each
+  only after confirming it's actually present there (don't assume).
+
+### 4. Verify
+Re-run and confirm the prediction. This closes the loop.
+
+- Re-run the exact repro from step 1. Confirm the new output matches the
+  predicted value, not just "looks different."
+- Test the boundaries around it: zero, very large, empty input, the adjacent
+  compounding frequencies, both tabs.
+- Confirm you didn't regress the cases that were already correct.
+- Re-run `yarn lint` (and `yarn build:local` if you touched more than one file).
+- Report faithfully: state the before/after numbers and the exact inputs. If a
+  case still fails or you skipped a check, say so.
+
+### If verification fails
+Do not silently retry a new guess. Stop, report what Verify actually showed, and
+treat that output as **new evidence for another Observe pass**. Each iteration
+ends with a report to the user, not a silent loop.
+
+## Reporting template
+
+```
+Repro:     <exact inputs / scenario>
+Observed:  <actual output>  (expected <value> from <source>)
+Cause:     <one sentence, tied to the delta>
+Fix:       <file:line, minimal change>
+Verified:  <re-run output = predicted>; boundaries checked: <list>
+```
+
+## Anti-patterns
+
+- Proposing a fix before running the code ("this should be it" — verify it *is*).
+- Verifying only the one case you fixed and declaring victory.
+- A large refactor offered as a bug fix — a symptom of a skipped Observe phase.
+- Assuming a fix in one calculator applies to the `-v2` or sibling versions
+  without checking each file.
+- Calling it done on a green compile alone; compiling is not behaving.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Releases are identified by deploy date.
 
 ### [2026-07-15]
 
-- TVM interest-rate tab now reports that no meaningful rate could be calculated, instead of a misleading cash-flow-signs error, when the only root falls below the -100% floor (#___).
+- TVM interest-rate tab now reports that no meaningful rate could be calculated, instead of a misleading cash-flow-signs error, when the only root falls below the -100% floor (#159).
 
 ## [2026-07-10]
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,56 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+Educational financial-decision-making prototype for early-career professionals, built with Stanford GSB's Initiative for Financial Decision Making (IFDM). It's a Next.js **static site** of interactive financial calculators, each designed to be embedded via `<iframe>` inside the Mighty Networks platform. Hosted on GitHub Pages.
+
+## Commands
+
+```bash
+nvm use              # match the Node version in .nvmrc before anything else
+yarn install         # this repo uses yarn (yarn@1.22.22), not npm
+yarn dev             # dev server with turbopack at http://localhost:3000
+yarn build:local     # plain next build, no static-export path juggling — use this to check a build compiles
+yarn lint            # next lint (eslint) — runs against app/ only
+```
+
+There is no test suite. Verification is manual: run `yarn dev` and exercise the calculator in the browser.
+
+### Deploying (branch-gated — do not run casually)
+
+Deploys publish to GitHub Pages via `gh-pages`. Each script refuses to run unless you're on the matching branch (`scripts/check-branch.js`):
+
+- `yarn deploy` → production, requires branch `1.x`, publishes to https://ifdm-learning.stanford.edu/
+- `yarn deploy:staging` → staging, requires branch `dev`, publishes to the `ifdm_learning_apps_staging` repo
+
+Flow: feature branch → PR into `dev` → `yarn deploy:staging` (QA) → PR `dev` into `1.x` → `yarn deploy` (prod). Full details in `docs/deployment.md`.
+
+## Architecture
+
+**Static export.** `next.config.ts` sets `output: 'export'`, so this is a fully static site — no server, no API routes, no runtime data fetching. Everything is client-side. `images.unoptimized: true` and `trailingSlash: true` are required for GitHub Pages.
+
+**`basePath` is environment-driven.** Production serves from a custom domain root (empty basePath); staging serves from a subpath and sets `NEXT_BASE_PATH=/ifdm_learning_apps_staging` in `build:staging`. If assets 404 in one environment but not the other, this is almost always the cause — never hardcode absolute asset paths.
+
+**One calculator = one route = one file.** Each calculator lives at `app/interactives/<name>/page.tsx` and is a single self-contained `"use client"` component. They do **not** share calculation logic — each file owns its own state (all inputs held as `string` in `useState`), its own financial math, its own validation/error rules, and constant tables (frequency options, constraints) defined at the top of the file. When fixing a bug in one calculator, do not assume the fix applies elsewhere; check each file. `app/interactives/time-value-money-calculator/page.tsx` is the richest example of the established pattern (typed constants, a `CONSTRAINTS` object, `FieldError[]` validation).
+
+Note the `-v2` variants (`mortgage-calculator-v2`, `present-value-calculator-v2`, `mortgage-refinancing-calculator-v2`) are the current versions; the un-suffixed ones are older and may be superseded — confirm which is linked/embedded before editing.
+
+**The home page auto-discovers routes.** `app/page.tsx` reads the `app/` directory at build time (`fs.readdirSync`) and lists every subdirectory containing a `page.*` file. Adding a calculator directory automatically adds it to the index — no manual registration.
+
+**Shared UI is shadcn/ui.** Reusable primitives live in `app/ui/components/` (button, card, input, select, slider, tabs, etc.), generated via shadcn (`components.json`, "new-york" style, lucide icons). Use `cn()` from `app/lib/utils.ts` (clsx + tailwind-merge) for class composition. Import via the `@/*` alias mapped to the repo root (e.g. `@/app/ui/components/card`).
+
+See `docs/calculator-global-rules.md` for the full calculator conventions (input handling, error/warning states, formatting, math fallbacks).
+
+## Styling conventions
+
+- **Tailwind v4** with CSS-first theming. The brand palette (Stanford colors: `lagunita`, `berry`, `palo-verde`, `navy`, `error #8C1515`, etc.) is defined as CSS variables in `app/ui/globals.css` under `@theme inline`, plus a few legacy tokens in `tailwind.config.js`. Prefer the named tokens over raw hex/rgba.
+- **Dark mode** is class-based (`darkMode: 'class'`). `app/lib/theme-toggle.tsx` toggles the `dark`/`light` class on `<html>` and persists to `localStorage`; it returns a placeholder until mounted to avoid hydration mismatch. Any color you add needs a dark-mode counterpart.
+- Fonts (Open Sans, Poppins) come from `app/ui/fonts.ts` via `next/font/google`.
+- Inline validation colors use `var(--color-inline-error)` and `var(--color-inline-warning)` (warning resolves to `#9A6207` light / `#C37C09` dark). See `docs/calculator-global-rules.md` sections 4-5.
+
+## Gotchas
+
+- No-cache headers are set in `app/layout.tsx` metadata because embeds are served through iframes and stale caches were a recurring problem.
+- Financial math is the sensitive surface here — the changelog shows repeated fixes to interest-rate solvers, edge cases (zero rate, high rate, cross-compounding frequency), and currency-input handling. Treat validation and solver edits carefully and test boundary values.


### PR DESCRIPTION
# SUMMARY

Adds a set of project skills under .claude/skills/ plus CLAUDE.md project guidance. No runtime/app code is touched — this is tooling for working in the repo.

What's included
- run-observe-propose-verify — a disciplined debug loop (Run → Observe → Propose → Verify) with an explicit can't-reproduce branch and a verify-fails loop-back, tuned to this repo's manual-verification workflow.

- rigorous-mathematician — a mathematically rigorous accounting/finance persona for deriving, reviewing, and auditing the calculators' financial math (derive from first principles, cross-check against an amortization schedule, probe boundary cases).

- new-calculator — scaffolds a new app/interactives//page.tsx following the established self-contained pattern from the time-value-money reference (typed constants, CONSTRAINTS, FieldError[] validation, string-based inputs, dark-mode tokens, aria).

- calculator-qa — a manual QA checklist (boundaries, currency input, validation, dark mode, accessibility, basePath/iframe), since the repo has no automated test suite.

- CLAUDE.md — project guidance for Claude Code.

# NOTES

- Skills auto-surface via their description triggers, or can be invoked explicitly (/new-calculator, etc.). They only shape how Claude behaves in-session — they don't add build/deploy automation.
- 
- The skills cross-reference each other (e.g. new-calculator and calculator-qa defer to rigorous-accountant for the math).
🤖 Generated with [Claude Code](https://claude.com/claude-code)